### PR TITLE
fix: race condition when clear shared prefs values after wipeAll

### DIFF
--- a/app/src/main/java/com/brainwallet/wallet/BRWalletManager.java
+++ b/app/src/main/java/com/brainwallet/wallet/BRWalletManager.java
@@ -232,12 +232,12 @@ public class BRWalletManager {
             @Override
             public void run() {
                 Timber.d("timber: Running peerManagerFreeEverything");
+                BRSharedPrefs.clearAllPrefs(ctx);
                 BRPeerManager.getInstance().peerManagerFreeEverything();
                 walletFreeEverything();
                 TransactionDataSource.getInstance(ctx).deleteAllTransactions();
                 MerkleBlockDataSource.getInstance(ctx).deleteAllBlocks();
                 PeerDataSource.getInstance(ctx).deleteAllPeers();
-                BRSharedPrefs.clearAllPrefs(ctx);
             }
         });
     }


### PR DESCRIPTION
## Overview
fix race condition when execute `wipeAll` the shared preferences should be cleared properly first before we add new values e.g. `phraseWritten`