### PR TITLE
Chore/revert testing core f683adf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 
 ## Easy and secure
 Brainwallet is a easy and fun way to use your crypto (Litecoin) and memorize your seed words
+git submodule update --init --recursive --remote

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "ltd.grunt.brainwallet"
         minSdk = 29
         targetSdk = 34
-        versionCode = 202503281
-        versionName = "v4.4.1"
+        versionCode = 202504211
+        versionName = "v4.4.7"
 
         multiDexEnabled = true
         base.archivesName.set("${defaultConfig.versionName}(${defaultConfig.versionCode})")

--- a/app/src/main/java/com/brainwallet/tools/manager/BRSharedPrefs.java
+++ b/app/src/main/java/com/brainwallet/tools/manager/BRSharedPrefs.java
@@ -1,7 +1,11 @@
 package com.brainwallet.tools.manager;
 
+import static com.brainwallet.tools.util.BRConstants.APP_VERSION_NAME_CODE;
+
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.health.connect.datatypes.AppInfo;
+import android.util.Log;
 
 import com.brainwallet.BrainwalletApp;
 import com.brainwallet.data.repository.SettingRepository;
@@ -10,8 +14,10 @@ import com.brainwallet.tools.util.BRConstants;
 import org.koin.java.KoinJavaComponent;
 import org.koin.mp.KoinPlatformTools_jvmKt;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Currency;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -76,36 +82,61 @@ public class BRSharedPrefs {
 
     //////////////////////////////////////////////////////////////////////////////
     //////////////////// Active Shared Preferences ///////////////////////////////
-    public static void putLastSyncTimestamp(Context activity, long time) {
-        SharedPreferences prefs = activity.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putLong("lastSyncTime", time);
-        editor.apply();
-    }
-    public static long getLastSyncTimestamp(Context activity) {
-        SharedPreferences prefs = activity.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
-        return prefs.getLong("lastSyncTime", 0L);
-    }
-    public static void putStartSyncTimestamp(Context activity, long time) {
-        SharedPreferences prefs = activity.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
+
+    public static void putStartSyncTimestamp(Context context, long time) {
+        if (context == null) {
+            Log.e("BRSharedPrefs", "Context is null in putStartSyncTimestamp!");
+            return;
+        }
+        SharedPreferences prefs = context.getSharedPreferences(BRConstants.PREFS_NAME, 0);
         SharedPreferences.Editor editor = prefs.edit();
         editor.putLong("startSyncTime", time);
         editor.apply();
     }
-    public static long getStartSyncTimestamp(Context activity) {
-        SharedPreferences prefs = activity.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
-        return prefs.getLong("startSyncTime", 0L);
+    public static long getStartSyncTimestamp(Context context) {
+        if (context == null) {
+            Log.e("BRSharedPrefs", "Context is null in getStartSyncTimestamp!");
+        }
+        SharedPreferences startSyncTime = context.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
+        return startSyncTime.getLong("startSyncTime", System.currentTimeMillis());
     }
 
-    public static void putSyncTimeElapsed(Context activity, long time) {
-        SharedPreferences prefs = activity.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
+    public static void putEndSyncTimestamp(Context context, long time) {
+
+        if (context == null) {
+            Log.e("BRSharedPrefs", "Context is null in putEndSyncTimestamp!");
+            return;
+        }
+
+        SharedPreferences prefs = context.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
-        editor.putLong("syncTimeElapsed", time);
+        editor.putLong("endSyncTime", time);
         editor.apply();
     }
-    public static long getSyncTimeElapsed(Context activity) {
-        SharedPreferences prefs = activity.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
-        return prefs.getLong("syncTimeElapsed", 0L);
+
+    public static String getSyncMetadata(Context context) {
+        SharedPreferences syncMetadata = context.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
+        return syncMetadata.getString("syncMetadata", " No Sync Duration metadata");
+    }
+
+    public static void putSyncMetadata(Context activity, long startSyncTime, long endSyncTime) {
+        SharedPreferences prefs = activity.getSharedPreferences(BRConstants.PREFS_NAME, 0);
+        SharedPreferences.Editor editor = prefs.edit();
+
+        double syncDuration = (double) (endSyncTime - startSyncTime) / 1_000.0 / 60.0;
+
+        SimpleDateFormat sdf = new SimpleDateFormat("MMM dd HH:mm");
+        Date startDate = new Date(startSyncTime);
+        Date endDate = new Date(endSyncTime);
+
+        String formattedMetadata = String.format("Duration: %3.2f mins\nStarted: %d (%s)\nEnded: %d (%s)",syncDuration,startSyncTime,sdf.format(startDate),endSyncTime,sdf.format(endDate));
+        editor.putString("syncMetadata", formattedMetadata);
+        editor.apply();
+    }
+
+    public static long getEndSyncTimestamp(Context context) {
+        SharedPreferences endSyncTime = context.getSharedPreferences(BRConstants.PREFS_NAME, Context.MODE_PRIVATE);
+        return endSyncTime.getLong("endSyncTime", System.currentTimeMillis());
     }
 
     public static boolean getPhraseWroteDown(Context context) {

--- a/app/src/main/java/com/brainwallet/tools/manager/SyncManager.java
+++ b/app/src/main/java/com/brainwallet/tools/manager/SyncManager.java
@@ -1,5 +1,7 @@
 package com.brainwallet.tools.manager;
 
+import static com.brainwallet.tools.manager.BRSharedPrefs.putSyncMetadata;
+
 import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -44,8 +46,6 @@ public class SyncManager {
             }
             syncTask = new SyncProgressTask();
             syncTask.start();
-            BRSharedPrefs.putStartSyncTimestamp(app, System.currentTimeMillis());
-            BRSharedPrefs.putSyncTimeElapsed(app, 0L);
             updateStartSyncData(app);
         } catch (IllegalThreadStateException ex) {
             Timber.e(ex);
@@ -54,41 +54,11 @@ public class SyncManager {
 
     private synchronized void updateStartSyncData(Context app) {
         final double progress = BRPeerManager.syncProgress(BRSharedPrefs.getStartHeight(app));
-        long startSync = BRSharedPrefs.getStartSyncTimestamp(app);
-        long lastSync = BRSharedPrefs.getLastSyncTimestamp(app);
-        long elapsed = BRSharedPrefs.getSyncTimeElapsed(app);
-
-        if (elapsed > 0L) {
-            elapsed = (System.currentTimeMillis() - lastSync) + elapsed;
-        }
-        else {
-            elapsed = 1L;
-        }
-        BRSharedPrefs.putLastSyncTimestamp(app, System.currentTimeMillis());
-        BRSharedPrefs.putSyncTimeElapsed(app, elapsed);
-        double minutesValue = ((double) elapsed / 1_000.0  / 60.0);
-        String minutesString = String.format( "%3.2f mins", minutesValue);
-        String millisecString = String.format( "%5d msec", elapsed);
-        Timber.d("timber: ||\nprogress: %s\nThread: %s\nrunning lastSyncingTime: %s\nelapsed: %s | %s", String.format( "%.2f", progress * 100.00),Thread.currentThread().getName(),String.valueOf(BRSharedPrefs.getLastSyncTimestamp(app)), millisecString, minutesString);
-
     }
 
     private synchronized void markFinishedSyncData(Context app) {
-        Timber.d("timber: || markFinish threadname:%s", Thread.currentThread().getName());
+        Timber.d("timber: || SYNC ELAPSE markFinish threadname:%s", Thread.currentThread().getName());
         final double progress = BRPeerManager.syncProgress(BRSharedPrefs.getStartHeight(app));
-        long startSync = BRSharedPrefs.getStartSyncTimestamp(app);
-        long lastSync = BRSharedPrefs.getLastSyncTimestamp(app);
-        long elapsed = BRSharedPrefs.getSyncTimeElapsed(app);
-        double minutesValue = ((double) elapsed / 1_000.0  / 60.0);
-        String minutesString = String.format( "%3.2f mins", minutesValue);
-        String millisecString = String.format( "%5d msec", elapsed);
-        Timber.d("timber: ||\ncompletedprogress: %s\nstartSyncTime: %s\nlastSyncingTime: %s\ntotalTimeelapsed: %s | %s", String.format( "%.2f", progress * 100.00),String.valueOf(startSync),String.valueOf(lastSync), millisecString, minutesString);
-
-        Bundle params = new Bundle();
-        params.putDouble("sync_time_elapsed", minutesValue);
-        params.putLong("sync_start_timestamp", startSync);
-        params.putLong("sync_last_timestamp", lastSync);
-        AnalyticsManager.logCustomEventWithParams(BRConstants._20230407_DCS, params);
     }
 
     public synchronized void stopSyncingProgressThread(Context app) {
@@ -139,7 +109,10 @@ public class SyncManager {
                 app = BreadActivity.getApp();
                 progressStatus = 0;
                 running = true;
-                Timber.d("timber: run: starting: %s", progressStatus);
+                long runTimeStamp = System.currentTimeMillis();
+                Timber.d("timber: run: starting: %s date: %d", progressStatus, runTimeStamp);
+                ///Set StartSync
+                BRSharedPrefs.putStartSyncTimestamp(app, runTimeStamp);
 
                 if (app != null) {
                     final long lastBlockTimeStamp = BRPeerManager.getInstance().getLastBlockTimestamp() * 1000;
@@ -162,6 +135,16 @@ public class SyncManager {
                         progressStatus = BRPeerManager.syncProgress(startHeight);
                         if (progressStatus == 1) {
                             running = false;
+                            /// Record sync time
+                            long startTimeStamp = BRSharedPrefs.getStartSyncTimestamp(app);
+                            long endSyncTimeStamp = System.currentTimeMillis();
+                            BRSharedPrefs.putEndSyncTimestamp(app, endSyncTimeStamp);
+
+                            double syncDuration = (double) (endSyncTimeStamp - startTimeStamp) / 1_000.0 / 60.0;
+                            /// only update if the sync duration is longer than 2 mins
+                           if (syncDuration > 2.0) {
+                                putSyncMetadata(app, startTimeStamp, endSyncTimeStamp);
+                           }
                             continue;
                         }
                         final long lastBlockTimeStamp = BRPeerManager.getInstance().getLastBlockTimestamp() * 1000;

--- a/app/src/main/java/com/brainwallet/ui/screens/home/composable/HomeSettingDrawerSheet.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/home/composable/HomeSettingDrawerSheet.kt
@@ -17,6 +17,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.AbstractComposeView
@@ -56,10 +59,12 @@ fun HomeSettingDrawerSheet(
 ) {
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
-    val lastSyncMetadata = BRSharedPrefs.getSyncMetadata(context)
+    var lastSyncMetadata by remember { mutableStateOf<String?>(null) }
+
 
     LaunchedEffect(Unit) {
         viewModel.onEvent(SettingsEvent.OnLoad(BRSharedPrefs.getShareData(context))) //currently just load analytics share data here
+        lastSyncMetadata = BRSharedPrefs.getSyncMetadata(context)
     }
 
     /// Layout values
@@ -177,9 +182,9 @@ fun HomeSettingDrawerSheet(
 
             item {
                 SettingRowItem(
-                    modifier = Modifier.height(100.dp),
+                    modifier = Modifier.height(120.dp),
                     title = stringResource(R.string.settings_title_sync_metadata),
-                    description = lastSyncMetadata
+                    description = lastSyncMetadata ?: ""
                 )
             }
 

--- a/app/src/main/java/com/brainwallet/ui/screens/home/composable/HomeSettingDrawerSheet.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/home/composable/HomeSettingDrawerSheet.kt
@@ -6,6 +6,7 @@ import android.util.AttributeSet
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
@@ -55,6 +56,7 @@ fun HomeSettingDrawerSheet(
 ) {
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
+    val lastSyncMetadata = BRSharedPrefs.getSyncMetadata(context)
 
     LaunchedEffect(Unit) {
         viewModel.onEvent(SettingsEvent.OnLoad(BRSharedPrefs.getShareData(context))) //currently just load analytics share data here
@@ -170,6 +172,14 @@ fun HomeSettingDrawerSheet(
                     onToggledDarkMode = {
                         viewModel.onEvent(SettingsEvent.OnToggleDarkMode)
                     }
+                )
+            }
+
+            item {
+                SettingRowItem(
+                    modifier = Modifier.height(100.dp),
+                    title = stringResource(R.string.settings_title_sync_metadata),
+                    description = lastSyncMetadata
                 )
             }
 

--- a/app/src/main/java/com/brainwallet/wallet/BRPeerManager.java
+++ b/app/src/main/java/com/brainwallet/wallet/BRPeerManager.java
@@ -48,6 +48,20 @@ public class BRPeerManager {
      * int (*networkIsReachable)(void *info))
      */
 
+    public static void txStatusUpdate() {
+        Timber.d("timber: txStatusUpdate");
+
+        for (OnTxStatusUpdate listener : statusUpdateListeners) {
+            if (listener != null) listener.onStatusUpdate();
+        }
+        BRExecutor.getInstance().forLightWeightBackgroundTasks().execute(new Runnable() {
+            @Override
+            public void run() {
+                updateLastBlockHeight(getCurrentBlockHeight());
+            }
+        });
+    }
+
     public static void syncStarted() {
         Context ctx = BrainwalletApp.getBreadContext();
         int startHeight = BRSharedPrefs.getStartHeight(ctx);
@@ -59,7 +73,6 @@ public class BRPeerManager {
     public static void syncSucceeded() {
         Context ctx = BrainwalletApp.getBreadContext();
         if (ctx == null) return;
-        BRSharedPrefs.putLastSyncTimestamp(ctx, System.currentTimeMillis());
         SyncManager.getInstance().updateAlarms(ctx);
         BRSharedPrefs.putAllowSpend(ctx, true);
         SyncManager.getInstance().stopSyncingProgressThread(ctx);
@@ -81,20 +94,6 @@ public class BRPeerManager {
 
         SyncManager.getInstance().stopSyncingProgressThread(ctx);
         if (onSyncFinished != null) onSyncFinished.onFinished();
-    }
-
-    public static void txStatusUpdate() {
-        Timber.d("timber: txStatusUpdate");
-
-        for (OnTxStatusUpdate listener : statusUpdateListeners) {
-            if (listener != null) listener.onStatusUpdate();
-        }
-        BRExecutor.getInstance().forLightWeightBackgroundTasks().execute(new Runnable() {
-            @Override
-            public void run() {
-                updateLastBlockHeight(getCurrentBlockHeight());
-            }
-        });
     }
 
     public static void saveBlocks(final BlockEntity[] blockEntities, final boolean replace) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -825,6 +825,7 @@
     <string name="settings_title_unlock">Unlock</string>
     <string name="settings_title_theme">Theme</string>
     <string name="settings_title_app_version">App version:</string>
+    <string name="settings_title_sync_metadata">Sync metadata:</string>
     <string name="settings_blockchain_litecoin_button">Sync</string>
     <string name="settings_blockchain_litecoin_description">Sync duration: >20 minutes</string>
     <string name="game_title">Game %1$d:</string>


### PR DESCRIPTION
# Why?
Now that we have a physical testbed, we can run full sync and look at the effects in real time.
This version reverts the core and android code to prior to merging  some sending issues.
