### PR TITLE
chore: open bread activity first then open moonpay widget

### DIFF
--- a/app/src/main/java/com/brainwallet/ui/screens/buylitecoin/BuyLitecoinScreen.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/buylitecoin/BuyLitecoinScreen.kt
@@ -149,6 +149,8 @@ fun BuyLitecoinScreen(
                 modifier = Modifier.align(Alignment.BottomCenter),
                 enabled = loadingState.visible.not(),
                 onClick = {
+                    //open bread activity first then open moonpay widget
+                    LegacyNavigation.restartBreadActivity(context)
                     LegacyNavigation.showMoonPayWidget(
                         context = context,
                         params = mapOf(


### PR DESCRIPTION
## Overview
open bread activity first then open moonpay widget, so when the user close the moonpay widget it will be go back to the bread activity