### PR TITLE
fix: android: Footer version label is obfuscated

### DIFF
--- a/app/src/main/java/com/brainwallet/ui/screens/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/welcome/WelcomeScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -89,7 +91,8 @@ fun WelcomeScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(BrainwalletTheme.colors.surface),
+            .background(BrainwalletTheme.colors.surface)
+            .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceBetween
     ) {


### PR DESCRIPTION
## Overview
fix Footer version label is obfuscated

## Issue
* https://github.com/gruntsoftware/android/issues/90

## Screenshots

| Before | After |
|--------|-------|
|  ![Screenshot_20250529_143730](https://github.com/user-attachments/assets/d9479283-db18-487d-aa79-f4ad89632a32) |  ![version after](https://github.com/user-attachments/assets/c958fc4b-8e99-4de3-8a95-e419fc2c143d) |
