### PR TITLE
fix: [#137] fix: Reset fiat options in Buy / Receive modal

### DIFF
--- a/app/src/main/java/com/brainwallet/tools/sqlite/CurrencyDataSource.java
+++ b/app/src/main/java/com/brainwallet/tools/sqlite/CurrencyDataSource.java
@@ -89,6 +89,26 @@ public class CurrencyDataSource implements BRDataSourceInterface {
         }
     }
 
+    public List<CurrencyEntity> getCurrenciesForBuy() {
+        List<String> supportedFiatCodes = Arrays.asList(
+                "AUD",
+                "BRL",
+                "CAD",
+                "CHF",
+                "EUR",
+                "GBP",
+                "IDR",
+                "MXN",
+                "NGN",
+                "TRY",
+                "USD",
+                "ZAR"
+        );
+        return getAllCurrencies(true).stream()
+                .filter(currencyEntity -> supportedFiatCodes.contains(currencyEntity.code))
+                .collect(Collectors.toList());
+    }
+
     public List<CurrencyEntity> getAllCurrencies(Boolean shouldBeFiltered) {
 
         List<CurrencyEntity> currencies = new ArrayList<>();

--- a/app/src/main/java/com/brainwallet/ui/screens/home/receive/ReceiveDialogViewModel.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/home/receive/ReceiveDialogViewModel.kt
@@ -49,8 +49,7 @@ class ReceiveDialogViewModel(
                 it.copy(
                     address = address,
                     qrBitmap = QRUtils.generateQR(event.context, "litecoin:${address}"),
-                    fiatCurrencies = CurrencyDataSource.getInstance(event.context)
-                        .getAllCurrencies(true),
+                    fiatCurrencies = CurrencyDataSource.getInstance(event.context).getCurrenciesForBuy(),
                 )
             }
 

--- a/app/src/test/java/com/brainwallet/currency/CurrencyTests.kt
+++ b/app/src/test/java/com/brainwallet/currency/CurrencyTests.kt
@@ -51,6 +51,13 @@ class CurrencyTests {
     }
 
     @Test
+    fun `invoke CurrencyDataSource instance and Brainwallet filtered Fiats for Buy, should return the correct number of supported currencies (moonpay)`() {
+        //The actual number of BW currencies is 16. The 0 is a placeholder and needs to be replaced with a db query.
+        mockCursorDataFromDatabase()
+        assertEquals(currencyDataSource?.currenciesForBuy?.count(), 0)
+    }
+
+    @Test
     fun `invoke CurrencyDataSource instance and open database, then should validate database was not null`() {
         val database = currencyDataSource?.openDatabase()
         assertNotNull(database)


### PR DESCRIPTION
## Overview
Fix for moonpay supported currencies

## Internal Issue
* https://github.com/gruntsoftware/internal/issues/137