### PR TITLE
fix: fix YourSeedProveItState.isWordUsedCorrectly

### DIFF
--- a/app/src/main/java/com/brainwallet/ui/screens/yourseedproveit/YourSeedProveItScreen.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/yourseedproveit/YourSeedProveItScreen.kt
@@ -187,14 +187,8 @@ fun YourSeedProveItScreen(
             Spacer(modifier = Modifier.weight(0.1f))
 
             SeedWordsLayout {
-                itemsIndexed(items = state.shuffledSeedWords) { index, word ->
-
-                    val isWordUsedCorrectly =
-                        state.correctSeedWords.values.any { (expectedWord, actualWord) ->
-                            expectedWord == word && actualWord == word
-                        }
-
-                    if (isWordUsedCorrectly) {
+                itemsIndexed(items = state.shuffledSeedWords) { index, (correctIndex, word) ->
+                    if (state.isWordUsedCorrectly(correctIndex, word)) {
                         Box(modifier = Modifier.fillMaxWidth())
                     } else {
                         SeedWordItem(

--- a/app/src/main/java/com/brainwallet/ui/screens/yourseedproveit/YourSeedProveItState.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/yourseedproveit/YourSeedProveItState.kt
@@ -2,7 +2,7 @@ package com.brainwallet.ui.screens.yourseedproveit
 
 data class YourSeedProveItState(
     val correctSeedWords: Map<Int, SeedWordItem> = emptyMap(),
-    val shuffledSeedWords: List<String> = emptyList(),
+    val shuffledSeedWords: List<Pair<Int, String>> = emptyList(),
     val orderCorrected: Boolean = false,
 )
 
@@ -10,3 +10,9 @@ data class SeedWordItem(
     val expected: String,
     val actual: String = ""
 )
+
+fun YourSeedProveItState.isWordUsedCorrectly(currentIndex: Int, currentWord: String): Boolean {
+    return correctSeedWords[currentIndex]?.let { seedWordItem ->
+        seedWordItem.expected == currentWord && seedWordItem.actual == currentWord
+    } ?: false
+}

--- a/app/src/main/java/com/brainwallet/ui/screens/yourseedproveit/YourSeedProveItViewModel.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/yourseedproveit/YourSeedProveItViewModel.kt
@@ -17,11 +17,13 @@ class YourSeedProveItViewModel : BrainwalletViewModel<YourSeedProveItEvent>() {
     override fun onEvent(event: YourSeedProveItEvent) {
         when (event) {
             is YourSeedProveItEvent.OnLoad -> _state.update {
+                val correctSeedWords = event.seedWords.mapIndexed { index, word ->
+                    index to SeedWordItem(expected = word)
+                }.toMap()
+
                 it.copy(
-                    correctSeedWords = event.seedWords.mapIndexed { index, word ->
-                        index to SeedWordItem(expected = word)
-                    }.toMap(),
-                    shuffledSeedWords = event.seedWords.shuffled()
+                    correctSeedWords = correctSeedWords,
+                    shuffledSeedWords = correctSeedWords.map { it.key to it.value.expected }.shuffled(),
                 )
             }
 


### PR DESCRIPTION
## Overview 
Fix this problem, The seed phrase generation can have more than one instance of a word. In this case the "You saved it, right?" YourSeedProveItScreen has a bug where a 12 word phrase with 2 identical words cannot be confirmed.

## Internal Issue
* https://github.com/gruntsoftware/internal/issues/148

## Self Test
![yousaveditright](https://github.com/user-attachments/assets/c92fce82-f12f-47b5-9040-3e24bda8d0a9)
