### PR TITLE
feat: add Unity Game Container

### DIFF
--- a/app/src/main/java/com/brainwallet/presenter/activities/BreadActivity.java
+++ b/app/src/main/java/com/brainwallet/presenter/activities/BreadActivity.java
@@ -64,7 +64,9 @@ import com.brainwallet.ui.screens.home.SettingsViewModel;
 import com.brainwallet.ui.screens.home.composable.HomeSettingDrawerComposeView;
 import com.brainwallet.ui.screens.home.receive.ReceiveDialogFragment;
 import com.brainwallet.ui.screens.home.receive.ReceiveDialogKt;
+import com.brainwallet.ui.composable.GameContainerComposeView;
 import com.brainwallet.util.PermissionUtil;
+import com.brainwallet.presenter.activities.GameTestActivity;
 import com.brainwallet.wallet.BRPeerManager;
 import com.brainwallet.wallet.BRWalletManager;
 import com.google.android.gms.tasks.Task;
@@ -105,6 +107,7 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
     private NavigationView navigationDrawer;
     private DrawerLayout drawerLayout;
     private HomeSettingDrawerComposeView homeSettingDrawerComposeView;
+    private GameContainerComposeView gameContainerComposeView;
 
     public static BreadActivity getApp() {
         return app;
@@ -237,6 +240,15 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
             if (BRAnimator.isClickAllowed()) {
                 drawerLayout.open();
             }
+        });
+        
+        menuBut.setOnLongClickListener(v -> {
+            if (BRAnimator.isClickAllowed()) {
+                Intent gameTestIntent = GameTestActivity.createIntent(this);
+                startActivity(gameTestIntent);
+                return true;
+            }
+            return false;
         });
     }
 
@@ -396,6 +408,7 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         navigationDrawer = findViewById(R.id.navigationDrawer);
         drawerLayout = findViewById(R.id.drawerLayout);
         homeSettingDrawerComposeView = findViewById(R.id.homeDrawerComposeView);
+        gameContainerComposeView = findViewById(R.id.gameContainerComposeView);
         homeSettingDrawerComposeView.observeBus(message -> {
             drawerLayout.close();
             if (SettingsViewModel.LEGACY_EFFECT_ON_LOCK.equals(message.getMessage())) {
@@ -445,6 +458,49 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         });
 
         balanceTxtV.append(":");
+        
+        setupGameContainer();
+    }
+    
+    private void setupGameContainer() {
+        if (gameContainerComposeView != null) {
+            gameContainerComposeView.setGameTitle("Brainwallet Unity Game");
+        }
+    }
+    
+    public void showGameContainer() {
+        if (gameContainerComposeView != null) {
+            gameContainerComposeView.setVisibility(android.view.View.VISIBLE);
+        }
+    }
+    
+    public void hideGameContainer() {
+        if (gameContainerComposeView != null) {
+            gameContainerComposeView.setVisibility(android.view.View.GONE);
+        }
+    }
+    
+    public void loadGame() {
+        if (gameContainerComposeView != null) {
+            showGameContainer();
+            gameContainerComposeView.loadUnityGame();
+        }
+    }
+    
+    public void pauseGame() {
+        if (gameContainerComposeView != null) {
+            gameContainerComposeView.pauseGame();
+        }
+    }
+    
+    public void resumeGame() {
+        if (gameContainerComposeView != null) {
+            gameContainerComposeView.resumeGame();
+        }
+    }
+    
+    public boolean isGameLoaded() {
+        return gameContainerComposeView != null && gameContainerComposeView.isGameLoaded();
     }
 
     @Override

--- a/app/src/main/java/com/brainwallet/presenter/activities/GameTestActivity.kt
+++ b/app/src/main/java/com/brainwallet/presenter/activities/GameTestActivity.kt
@@ -1,0 +1,99 @@
+package com.brainwallet.presenter.activities
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.brainwallet.R
+import com.brainwallet.ui.composable.GameContainerComposeView
+
+class GameTestActivity : AppCompatActivity() {
+    
+    private lateinit var gameContainerView: GameContainerComposeView
+    private lateinit var loadGameButton: Button
+    private lateinit var pauseResumeButton: Button
+    private lateinit var restartButton: Button
+    private lateinit var showHideButton: Button
+    
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_game_test)
+        
+        initializeViews()
+        setupClickListeners()
+        setupGameContainer()
+    }
+    
+    private fun initializeViews() {
+        gameContainerView = findViewById(R.id.gameContainerComposeView)
+        loadGameButton = findViewById(R.id.loadGameButton)
+        pauseResumeButton = findViewById(R.id.pauseResumeButton)
+        restartButton = findViewById(R.id.restartButton)
+        showHideButton = findViewById(R.id.showHideButton)
+    }
+    
+    private fun setupClickListeners() {
+        loadGameButton.setOnClickListener {
+            gameContainerView.loadUnityGame()
+            updateButtonStates()
+            showToast("Loading Unity Game...")
+        }
+        
+        pauseResumeButton.setOnClickListener {
+            if (gameContainerView.isGamePaused()) {
+                gameContainerView.resumeGame()
+                showToast("Game Resumed")
+            } else {
+                gameContainerView.pauseGame()
+                showToast("Game Paused")
+            }
+            updateButtonStates()
+        }
+        
+        restartButton.setOnClickListener {
+            gameContainerView.restartGame()
+            updateButtonStates()
+            showToast("Game Restarted")
+        }
+        
+        showHideButton.setOnClickListener {
+            if (gameContainerView.visibility == android.view.View.VISIBLE) {
+                gameContainerView.visibility = android.view.View.GONE
+                showHideButton.text = "Show Game Container"
+            } else {
+                gameContainerView.visibility = android.view.View.VISIBLE
+                showHideButton.text = "Hide Game Container"
+            }
+        }
+    }
+    
+    private fun setupGameContainer() {
+        gameContainerView.setGameTitle("Brainwallet Test Game")
+        updateButtonStates()
+    }
+    
+    private fun updateButtonStates() {
+        val isGameLoaded = gameContainerView.isGameLoaded()
+        val isGamePaused = gameContainerView.isGamePaused()
+        
+        loadGameButton.isEnabled = !isGameLoaded
+        pauseResumeButton.isEnabled = isGameLoaded
+        restartButton.isEnabled = isGameLoaded
+        
+        pauseResumeButton.text = if (isGamePaused) "Resume Game" else "Pause Game"
+        
+        loadGameButton.text = if (isGameLoaded) "Game Loaded" else "Load Game"
+    }
+    
+    private fun showToast(message: String) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+    
+    companion object {
+        fun createIntent(context: Context): Intent {
+            return Intent(context, GameTestActivity::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/brainwallet/presenter/fragments/GameFragment.kt
+++ b/app/src/main/java/com/brainwallet/presenter/fragments/GameFragment.kt
@@ -1,0 +1,76 @@
+package com.brainwallet.presenter.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.brainwallet.R
+import com.brainwallet.ui.composable.GameContainerComposeView
+import com.brainwallet.ui.composable.GameContainerState
+
+class GameFragment : Fragment() {
+    
+    private var gameContainerView: GameContainerComposeView? = null
+    
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_game, container, false)
+    }
+    
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        
+        gameContainerView = view.findViewById(R.id.gameContainerComposeView)
+        setupGameContainer()
+    }
+    
+    private fun setupGameContainer() {
+        gameContainerView?.apply {
+            setGameTitle("Brainwallet Unity Game")
+            updateGameState(
+                GameContainerState(
+                    gameTitle = "Brainwallet Unity Game"
+                )
+            )
+        }
+    }
+    
+    fun loadGame() {
+        gameContainerView?.loadUnityGame()
+    }
+    
+    fun pauseGame() {
+        gameContainerView?.pauseGame()
+    }
+    
+    fun resumeGame() {
+        gameContainerView?.resumeGame()
+    }
+    
+    fun restartGame() {
+        gameContainerView?.restartGame()
+    }
+    
+    fun isGameLoaded(): Boolean {
+        return gameContainerView?.isGameLoaded() ?: false
+    }
+    
+    fun isGamePaused(): Boolean {
+        return gameContainerView?.isGamePaused() ?: false
+    }
+    
+    override fun onDestroyView() {
+        super.onDestroyView()
+        gameContainerView = null
+    }
+    
+    companion object {
+        fun newInstance(): GameFragment {
+            return GameFragment()
+        }
+    }
+}

--- a/app/src/main/java/com/brainwallet/ui/composable/GameContainer.kt
+++ b/app/src/main/java/com/brainwallet/ui/composable/GameContainer.kt
@@ -1,0 +1,424 @@
+package com.brainwallet.ui.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+data class GameContainerState(
+    val isUnityLoaded: Boolean = false,
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+    val gameTitle: String = "Unity Game",
+    val isGamePaused: Boolean = false
+)
+
+sealed class GameContainerAction {
+    object LoadUnity : GameContainerAction()
+    object PauseGame : GameContainerAction()
+    object ResumeGame : GameContainerAction()
+    object RestartGame : GameContainerAction()
+    object DismissError : GameContainerAction()
+}
+
+@Composable
+fun GameContainer(
+    modifier: Modifier = Modifier,
+    gameState: GameContainerState = GameContainerState(),
+    onAction: (GameContainerAction) -> Unit = {}
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .testTag("game_container")
+    ) {
+        when {
+            gameState.isLoading -> {
+                GameLoadingContent(
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+            
+            gameState.errorMessage != null -> {
+                GameErrorContent(
+                    errorMessage = gameState.errorMessage,
+                    onRetry = { onAction(GameContainerAction.LoadUnity) },
+                    onDismiss = { onAction(GameContainerAction.DismissError) },
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+            
+            gameState.isUnityLoaded -> {
+                UnityGameContent(
+                    gameTitle = gameState.gameTitle,
+                    isGamePaused = gameState.isGamePaused,
+                    onPause = { onAction(GameContainerAction.PauseGame) },
+                    onResume = { onAction(GameContainerAction.ResumeGame) },
+                    onRestart = { onAction(GameContainerAction.RestartGame) },
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+            
+            else -> {
+                GamePlaceholderContent(
+                    onLoadGame = { onAction(GameContainerAction.LoadUnity) },
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GameLoadingContent(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .size(48.dp)
+                .testTag("loading_indicator"),
+            color = Color.White,
+            strokeWidth = 4.dp
+        )
+        
+        Text(
+            text = "Loading Unity Game...",
+            color = Color.White,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.testTag("loading_text")
+        )
+    }
+}
+
+@Composable
+private fun GameErrorContent(
+    errorMessage: String,
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .padding(24.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.Red.copy(alpha = 0.1f))
+            .border(1.dp, Color.Red.copy(alpha = 0.3f), RoundedCornerShape(12.dp))
+            .padding(20.dp)
+            .testTag("error_container"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "Game Error",
+            color = Color.Red,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+        
+        Text(
+            text = errorMessage,
+            color = Color.White,
+            fontSize = 14.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.testTag("error_message")
+        )
+        
+        Button(
+            onClick = onRetry,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color.Red,
+                contentColor = Color.White
+            ),
+            modifier = Modifier.testTag("retry_button")
+        ) {
+            Text(text = "Retry")
+        }
+        
+        Button(
+            onClick = onDismiss,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color.Transparent,
+                contentColor = Color.White
+            ),
+            modifier = Modifier.testTag("dismiss_button")
+        ) {
+            Text(text = "Dismiss")
+        }
+    }
+}
+
+@Composable
+private fun UnityGameContent(
+    gameTitle: String,
+    isGamePaused: Boolean,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onRestart: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(modifier = modifier.testTag("unity_game_content")) {
+        UnityGamePlaceholder(
+            gameTitle = gameTitle,
+            modifier = Modifier.fillMaxSize()
+        )
+        
+        if (isGamePaused) {
+            GamePausedOverlay(
+                onResume = onResume,
+                onRestart = onRestart,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+        
+        GameControlsOverlay(
+            isGamePaused = isGamePaused,
+            onPause = onPause,
+            onResume = onResume,
+            modifier = Modifier.align(Alignment.TopEnd)
+        )
+    }
+}
+
+@Composable
+private fun UnityGamePlaceholder(
+    gameTitle: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .background(Color.DarkGray)
+            .testTag("unity_placeholder"),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = gameTitle,
+                color = Color.White,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center
+            )
+            
+            Text(
+                text = "Unity Game Will Load Here",
+                color = Color.Gray,
+                fontSize = 14.sp,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun GamePausedOverlay(
+    onResume: () -> Unit,
+    onRestart: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .background(Color.Black.copy(alpha = 0.7f))
+            .testTag("pause_overlay"),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "Game Paused",
+                color = Color.White,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            
+            Button(
+                onClick = onResume,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.Green,
+                    contentColor = Color.White
+                ),
+                modifier = Modifier.testTag("resume_button")
+            ) {
+                Text(text = "Resume")
+            }
+            
+            Button(
+                onClick = onRestart,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.Blue,
+                    contentColor = Color.White
+                ),
+                modifier = Modifier.testTag("restart_button")
+            ) {
+                Text(text = "Restart")
+            }
+        }
+    }
+}
+
+@Composable
+private fun GameControlsOverlay(
+    isGamePaused: Boolean,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Button(
+        onClick = if (isGamePaused) onResume else onPause,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Color.Black.copy(alpha = 0.6f),
+            contentColor = Color.White
+        ),
+        modifier = modifier
+            .padding(16.dp)
+            .testTag("pause_resume_button")
+    ) {
+        Text(text = if (isGamePaused) "Resume" else "Pause")
+    }
+}
+
+@Composable
+private fun GamePlaceholderContent(
+    onLoadGame: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .padding(24.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.Gray.copy(alpha = 0.2f))
+            .border(2.dp, Color.Gray.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
+            .padding(32.dp)
+            .testTag("placeholder_content"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        Text(
+            text = "🎮",
+            fontSize = 48.sp,
+            textAlign = TextAlign.Center
+        )
+        
+        Text(
+            text = "Unity Game Container",
+            color = Color.White,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+        
+        Text(
+            text = "Ready to embed Unity game.\nClick below to simulate loading.",
+            color = Color.Gray,
+            fontSize = 14.sp,
+            textAlign = TextAlign.Center,
+            lineHeight = 20.sp
+        )
+        
+        Button(
+            onClick = onLoadGame,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = Color.White
+            ),
+            modifier = Modifier.testTag("load_game_button")
+        ) {
+            Text(text = "Load Game")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun GameContainerPreview() {
+    MaterialTheme {
+        GameContainer()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun GameContainerLoadingPreview() {
+    MaterialTheme {
+        GameContainer(
+            gameState = GameContainerState(isLoading = true)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun GameContainerErrorPreview() {
+    MaterialTheme {
+        GameContainer(
+            gameState = GameContainerState(
+                errorMessage = "Failed to load Unity game. Please check your connection."
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun GameContainerLoadedPreview() {
+    MaterialTheme {
+        GameContainer(
+            gameState = GameContainerState(
+                isUnityLoaded = true,
+                gameTitle = "Brainwallet Game"
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun GameContainerPausedPreview() {
+    MaterialTheme {
+        GameContainer(
+            gameState = GameContainerState(
+                isUnityLoaded = true,
+                isGamePaused = true,
+                gameTitle = "Brainwallet Game"
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/brainwallet/ui/composable/GameContainerComposeView.kt
+++ b/app/src/main/java/com/brainwallet/ui/composable/GameContainerComposeView.kt
@@ -1,0 +1,103 @@
+package com.brainwallet.ui.composable
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import com.brainwallet.ui.theme.BrainwalletTheme
+
+class GameContainerComposeView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : ComposeView(context, attrs, defStyleAttr) {
+
+    private var gameContainerState by mutableStateOf(GameContainerState())
+    
+    init {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        
+        setContent {
+            BrainwalletTheme {
+                GameContainer(
+                    gameState = gameContainerState,
+                    onAction = ::handleGameAction
+                )
+            }
+        }
+    }
+    
+    fun updateGameState(newState: GameContainerState) {
+        gameContainerState = newState
+    }
+    
+    fun loadUnityGame() {
+        gameContainerState = gameContainerState.copy(isLoading = true)
+        
+        simulateUnityLoading { success ->
+            if (success) {
+                gameContainerState = gameContainerState.copy(
+                    isLoading = false,
+                    isUnityLoaded = true,
+                    errorMessage = null
+                )
+            } else {
+                gameContainerState = gameContainerState.copy(
+                    isLoading = false,
+                    isUnityLoaded = false,
+                    errorMessage = "Failed to load Unity game. Please try again."
+                )
+            }
+        }
+    }
+    
+    fun pauseGame() {
+        if (gameContainerState.isUnityLoaded) {
+            gameContainerState = gameContainerState.copy(isGamePaused = true)
+        }
+    }
+    
+    fun resumeGame() {
+        if (gameContainerState.isUnityLoaded) {
+            gameContainerState = gameContainerState.copy(isGamePaused = false)
+        }
+    }
+    
+    fun restartGame() {
+        if (gameContainerState.isUnityLoaded) {
+            gameContainerState = gameContainerState.copy(isGamePaused = false)
+        }
+    }
+    
+    fun setGameTitle(title: String) {
+        gameContainerState = gameContainerState.copy(gameTitle = title)
+    }
+    
+    fun isGameLoaded(): Boolean = gameContainerState.isUnityLoaded
+    
+    fun isGamePaused(): Boolean = gameContainerState.isGamePaused
+    
+    fun hasError(): Boolean = gameContainerState.errorMessage != null
+    
+    private fun handleGameAction(action: GameContainerAction) {
+        when (action) {
+            is GameContainerAction.LoadUnity -> loadUnityGame()
+            is GameContainerAction.PauseGame -> pauseGame()
+            is GameContainerAction.ResumeGame -> resumeGame()
+            is GameContainerAction.RestartGame -> restartGame()
+            is GameContainerAction.DismissError -> {
+                gameContainerState = gameContainerState.copy(errorMessage = null)
+            }
+        }
+    }
+    
+    private fun simulateUnityLoading(onComplete: (Boolean) -> Unit) {
+        postDelayed({
+            val success = (0..10).random() > 2
+            onComplete(success)
+        }, 2000)
+    }
+}

--- a/app/src/main/res/layout/activity_bread.xml
+++ b/app/src/main/res/layout/activity_bread.xml
@@ -132,12 +132,19 @@
 
             </LinearLayout>
 
+            <com.brainwallet.ui.composable.GameContainerComposeView
+                android:id="@+id/gameContainerComposeView"
+                android:layout_width="match_parent"
+                android:layout_height="200dp"
+                android:layout_below="@+id/toolbar_layout"
+                android:visibility="gone" />
+
             <FrameLayout
                 android:id="@+id/fragment_container"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_above="@+id/bottomNav"
-                android:layout_below="@+id/toolbar_layout" />
+                android:layout_below="@+id/gameContainerComposeView" />
 
             <com.google.android.material.bottomnavigation.BottomNavigationView
                 android:id="@+id/bottomNav"

--- a/app/src/main/res/layout/activity_game_test.xml
+++ b/app/src/main/res/layout/activity_game_test.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:background="@color/midnight"
+    tools:context=".presenter.activities.GameTestActivity">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="GameContainer Test Activity"
+        android:textColor="@color/white"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:layout_marginBottom="16dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginBottom="16dp">
+
+        <Button
+            android:id="@+id/loadGameButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="8dp"
+            android:text="Load Game"
+            android:backgroundTint="@color/blue" />
+
+        <Button
+            android:id="@+id/pauseResumeButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            android:text="Pause Game"
+            android:backgroundTint="@color/orange"
+            android:enabled="false" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginBottom="16dp">
+
+        <Button
+            android:id="@+id/restartButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="8dp"
+            android:text="Restart Game"
+            android:backgroundTint="@color/green"
+            android:enabled="false" />
+
+        <Button
+            android:id="@+id/showHideButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            android:text="Hide Game Container"
+            android:backgroundTint="@color/gray" />
+
+    </LinearLayout>
+
+    <com.brainwallet.ui.composable.GameContainerComposeView
+        android:id="@+id/gameContainerComposeView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:background="@android:color/black" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_game.xml
+++ b/app/src/main/res/layout/fragment_game.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black"
+    tools:context=".presenter.fragments.GameFragment">
+
+    <com.brainwallet.ui.composable.GameContainerComposeView
+        android:id="@+id/gameContainerComposeView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>

--- a/app/src/test/java/com/brainwallet/ui/composable/GameContainerTest.kt
+++ b/app/src/test/java/com/brainwallet/ui/composable/GameContainerTest.kt
@@ -1,0 +1,228 @@
+package com.brainwallet.ui.composable
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.brainwallet.ui.theme.BrainwalletTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GameContainerTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun gameContainer_initialState_showsPlaceholder() {
+        composeTestRule.setContent {
+            BrainwalletTheme {
+                GameContainer()
+            }
+        }
+
+        composeTestRule.onNodeWithTag("game_container").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("placeholder_content").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Unity Game Container").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("load_game_button").assertIsDisplayed()
+    }
+
+    @Test
+    fun gameContainer_loadingState_showsLoadingIndicator() {
+        val loadingState = GameContainerState(isLoading = true)
+
+        composeTestRule.setContent {
+            BrainwalletTheme {
+                GameContainer(gameState = loadingState)
+            }
+        }
+
+        composeTestRule.onNodeWithTag("loading_indicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("loading_text").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Loading Unity Game...").assertIsDisplayed()
+    }
+
+    @Test
+    fun gameContainer_errorState_showsErrorMessage() {
+        val errorState = GameContainerState(
+            errorMessage = "Failed to load Unity game"
+        )
+
+        composeTestRule.setContent {
+            BrainwalletTheme {
+                GameContainer(gameState = errorState)
+            }
+        }
+
+        composeTestRule.onNodeWithTag("error_container").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("error_message").assertTextContains("Failed to load Unity game")
+        composeTestRule.onNodeWithTag("retry_button").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("dismiss_button").assertIsDisplayed()
+    }
+
+    @Test
+    fun gameContainer_loadedState_showsUnityContent() {
+        val loadedState = GameContainerState(
+            isUnityLoaded = true,
+            gameTitle = "Test Game"
+        )
+
+        composeTestRule.setContent {
+            BrainwalletTheme {
+                GameContainer(gameState = loadedState)
+            }
+        }
+
+        composeTestRule.onNodeWithTag("unity_game_content").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("unity_placeholder").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Test Game").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("pause_resume_button").assertIsDisplayed()
+    }
+
+    @Test
+    fun gameContainer_pausedState_showsPauseOverlay() {
+        val pausedState = GameContainerState(
+            isUnityLoaded = true,
+            isGamePaused = true,
+            gameTitle = "Test Game"
+        )
+
+        composeTestRule.setContent {
+            BrainwalletTheme {
+                GameContainer(gameState = pausedState)
+            }
+        }
+
+        composeTestRule.onNodeWithTag("pause_overlay").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Game Paused").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("resume_button").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("restart_button").assertIsDisplayed()
+    }
+
+    @Test
+    fun gameContainer_loadGameButton_triggersLoadAction() {
+        var actionTriggered: GameContainerAction? = null
+
+        composeTestRule.setContent {
+            BrainwalletTheme {
+                GameContainer(
+                    onAction = { action -> actionTriggered = action }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("load_game_button").performClick()
+
+        assert(actionTriggered is GameContainerAction.LoadUnity)
+    }
+
+    @Test
+    fun gameContainer_pauseButton_triggersPauseAction() {
+        var actionTriggered: GameContainerAction? = null
+        val loadedState = GameContainerState(isUnityLoaded = true)
+
+        composeTestRule.setContent {
+            BrainwalletTheme {
+                GameContainer(
+                    gameState = loadedState,
+                    onAction = { action -> actionTriggered = action }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("pause_resume_button").performClick()
+
+        assert(actionTriggered is GameContainerAction.PauseGame)
+    }
+
+    @Test
+    fun gameContainer_resumeButton_triggersResumeAction() {
+        var actionTriggered: GameContainerAction? = null
+        val pausedState = GameContainerState(
+            isUnityLoaded = true,
+            isGamePaused = true
+        )
+
+        composeTestRule.setContent {
+            BrainwalletTheme {
+                GameContainer(
+                    gameState = pausedState,
+                    onAction = { action -> actionTriggered = action }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("pause_resume_button").performClick()
+
+        assert(actionTriggered is GameContainerAction.ResumeGame)
+    }
+
+    @Test
+    fun gameContainer_retryButton_triggersLoadAction() {
+        var actionTriggered: GameContainerAction? = null
+        val errorState = GameContainerState(
+            errorMessage = "Test error"
+        )
+
+        composeTestRule.setContent {
+            BrainwalletTheme {
+                GameContainer(
+                    gameState = errorState,
+                    onAction = { action -> actionTriggered = action }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("retry_button").performClick()
+
+        assert(actionTriggered is GameContainerAction.LoadUnity)
+    }
+
+    @Test
+    fun gameContainer_dismissButton_triggersDismissAction() {
+        var actionTriggered: GameContainerAction? = null
+        val errorState = GameContainerState(
+            errorMessage = "Test error"
+        )
+
+        composeTestRule.setContent {
+            BrainwalletTheme {
+                GameContainer(
+                    gameState = errorState,
+                    onAction = { action -> actionTriggered = action }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("dismiss_button").performClick()
+
+        assert(actionTriggered is GameContainerAction.DismissError)
+    }
+
+    @Test
+    fun gameContainer_restartButton_triggersRestartAction() {
+        var actionTriggered: GameContainerAction? = null
+        val pausedState = GameContainerState(
+            isUnityLoaded = true,
+            isGamePaused = true
+        )
+
+        composeTestRule.setContent {
+            BrainwalletTheme {
+                GameContainer(
+                    gameState = pausedState,
+                    onAction = { action -> actionTriggered = action }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("restart_button").performClick()
+
+        assert(actionTriggered is GameContainerAction.RestartGame)
+    }
+}


### PR DESCRIPTION
This commit lays the foundational Android-side architecture for embedding a Unity game using Jetpack Compose. It introduces the GameContainer composable, designed to manage the lifecycle and UI states (loading, loaded, paused, error) of the Unity instance.

This implementation serves as a proof-of-concept to demonstrate the proposed coding style and architectural approach.

Key Components:

- GameContainer.kt: A stateful composable that will host the Unity player view and display UI controls and status indicators.
- GameContainerComposeView.kt: A bridge to allow using the GameContainer composable within traditional XML layouts.
- GameTestActivity.kt / GameFragment.kt: Example implementations showcasing how to control the GameContainer (e.g., load, pause, resume) from an Activity or Fragment.

Current Status:
This code is a structural placeholder and does not yet include the embedded UnityPlayer. The intention is to integrate the UnityPlayer view directly within the GameContainer composable in a future commit. The current setup is designed to make this integration straightforward once a compilable Unity library is available.