### PR TITLE
bug(#213): Unable to drag and drop seed phrase into last row on small or split screen

### DIFF
--- a/app/src/main/java/com/brainwallet/ui/composable/utils/AutoScrollController.kt
+++ b/app/src/main/java/com/brainwallet/ui/composable/utils/AutoScrollController.kt
@@ -1,0 +1,71 @@
+package com.brainwallet.ui.composable.utils
+
+import android.view.View
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.toAndroidDragEvent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+class AutoScrollController(
+    private val scrollState: ScrollState,
+    private val view: View,
+    private val edgeSlopPx: Float,
+    private val stepPx: Float,
+    private val scope: CoroutineScope
+) {
+    private var job: Job? = null
+    private var dir = 0
+
+    fun update(event: DragAndDropEvent) {
+        val y = event.toAndroidDragEvent().y
+        val h = view.height.toFloat().coerceAtLeast(1f)
+        val newDir = when {
+            y < edgeSlopPx -> -1
+            y > h - edgeSlopPx -> 1
+            else -> 0
+        }
+        setDir(newDir)
+    }
+
+    fun stop() = setDir(0)
+
+    private fun setDir(newDir: Int) {
+        if (newDir == dir) return
+        dir = newDir
+        job?.cancel()
+        if (dir != 0) {
+            job = scope.launch {
+                while (isActive && dir != 0) {
+                    scrollState.scrollBy(stepPx * dir)
+                    delay(16)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun rememberAutoScrollController(
+    scrollState: ScrollState
+): AutoScrollController {
+    val scope = rememberCoroutineScope()
+    val view = LocalView.current
+    val density = LocalDensity.current
+    val edgeSlopPx = with(density) { 72.dp.toPx() }
+    val stepPx = with(density) { 28.dp.toPx() }
+
+    return remember {
+        AutoScrollController(scrollState, view, edgeSlopPx, stepPx, scope)
+    }
+}

--- a/app/src/main/java/com/brainwallet/ui/screens/yourseedproveit/YourSeedProveItScreen.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/yourseedproveit/YourSeedProveItScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.draganddrop.dragAndDropSource
 import androidx.compose.foundation.draganddrop.dragAndDropTarget
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -48,8 +49,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.brainwallet.R
+import com.brainwallet.data.model.AppSetting
 import com.brainwallet.navigation.OnNavigate
 import com.brainwallet.navigation.Route
 import com.brainwallet.navigation.UiEffect
@@ -58,68 +61,86 @@ import com.brainwallet.ui.composable.BrainwalletTopAppBar
 import com.brainwallet.ui.composable.LargeButton
 import com.brainwallet.ui.composable.SeedWordItem
 import com.brainwallet.ui.composable.SeedWordsLayout
-import org.koin.compose.koinInject
+import com.brainwallet.ui.composable.utils.AutoScrollController
+import com.brainwallet.ui.composable.utils.rememberAutoScrollController
+import com.brainwallet.ui.theme.BrainwalletAppTheme
+import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun YourSeedProveItScreen(
     onNavigate: OnNavigate,
     seedWords: List<String>,
-    viewModel: YourSeedProveItViewModel = koinInject()
+    modifier: Modifier = Modifier,
+    viewModel: YourSeedProveItViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
-
-    /// Layout values
-    val columnPadding = 12
-    val horizontalVerticalSpacing = 8
-    val spacerHeight = 48
-    val maxItemsPerRow = 3
 
     val clickAudioPlayer = remember { MediaPlayer.create(context, R.raw.clickseedword) }
     val errorAudioPlayer = remember { MediaPlayer.create(context, R.raw.errorsound) }
     val coinAudioPlayer = remember { MediaPlayer.create(context, R.raw.coinflip) }
 
-    LaunchedEffect(Unit) {
-        viewModel.onEvent(YourSeedProveItEvent.OnLoad(seedWords))
-    }
+    LaunchedEffect(Unit) { viewModel.onEvent(YourSeedProveItEvent.OnLoad(seedWords)) }
+    LaunchedEffect(state.orderCorrected) { if (state.orderCorrected) coinAudioPlayer.start() }
 
-    LaunchedEffect(state.orderCorrected) {
-        if (state.orderCorrected) {
-            coinAudioPlayer.start()
-        }
-    }
+    YourSeedProveItScreen(
+        state = state,
+        modifier = modifier,
+        onNavigate = onNavigate,
+        onEvent = viewModel::onEvent,
+        onCorrect = { clickAudioPlayer.start() },
+        onWrong = { errorAudioPlayer.start() }
+    )
+}
 
+@Composable
+private fun YourSeedProveItScreen(
+    state: YourSeedProveItState,
+    modifier: Modifier = Modifier,
+    onNavigate: OnNavigate = {},
+    onEvent: (YourSeedProveItEvent) -> Unit = {},
+    onCorrect: () -> Unit = {},
+    onWrong: () -> Unit = {}
+) {
+    val scrollState = rememberScrollState()
+    val autoScrollController = rememberAutoScrollController(scrollState)
     BrainwalletScaffold(
+        modifier = modifier,
         topBar = {
             BrainwalletTopAppBar(
                 navigationIcon = {
-                    IconButton(
-                        onClick = { onNavigate.invoke(UiEffect.Navigate.Back()) },
-                    ) {
+                    IconButton(onClick = { onNavigate.invoke(UiEffect.Navigate.Back()) }) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.back),
                         )
                     }
-                })
+                }
+            )
         },
     ) { paddingValues ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .padding(columnPadding.dp)
-                .verticalScroll(rememberScrollState()),
+                .padding(12.dp)
+                .verticalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(horizontalVerticalSpacing.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            // --- Header ---
             Text(
-                text = stringResource(if (state.orderCorrected) R.string.you_saved_your_keys else R.string.you_saved_it_right),
+                text = stringResource(
+                    if (state.orderCorrected) R.string.you_saved_your_keys
+                    else R.string.you_saved_it_right
+                ),
                 style = MaterialTheme.typography.headlineSmall,
             )
-
             Text(
-                text = stringResource(if (state.orderCorrected) R.string.you_saved_your_keys_desc else R.string.you_saved_it_right_desc),
+                text = stringResource(
+                    if (state.orderCorrected) R.string.you_saved_your_keys_desc
+                    else R.string.you_saved_it_right_desc
+                ),
                 style = MaterialTheme.typography.bodyMedium.copy(
                     textAlign = TextAlign.Center,
                     color = Color.Gray
@@ -128,66 +149,56 @@ fun YourSeedProveItScreen(
 
             Spacer(modifier = Modifier.weight(0.1f))
 
+            // --- Correct words area ---
             SeedWordsLayout {
-                itemsIndexed(items = state.correctSeedWords.values.toList()) { index: Int, (expectedWord, actualWord): SeedWordItem ->
-                    val label = if (expectedWord != actualWord && actualWord.isEmpty()) {
-                        "${index + 1}"
-                    } else {
-                        "${index + 1} $actualWord"
-                    }
+                itemsIndexed(state.correctSeedWords.values.toList()) { index, (expected, actual) ->
+                    val label =
+                        if (expected != actual && actual.isEmpty()) "${index + 1}"
+                        else "${index + 1} $actual"
 
                     SeedWordItem(
                         modifier = Modifier
                             .fillMaxWidth()
                             .dragAndDropTarget(
-                                shouldStartDragAndDrop = { event ->
-                                    event
-                                        .mimeTypes()
-                                        .contains(ClipDescription.MIMETYPE_TEXT_PLAIN)
+                                shouldStartDragAndDrop = { e ->
+                                    e.mimeTypes().contains(ClipDescription.MIMETYPE_TEXT_PLAIN)
                                 },
                                 target = remember {
-                                    object : DragAndDropTarget {
-                                        override fun onDrop(event: DragAndDropEvent): Boolean {
-                                            val text = event.toAndroidDragEvent().clipData
-                                                ?.getItemAt(0)?.text
-
-                                            viewModel.onEvent(
-                                                YourSeedProveItEvent.OnDropSeedWordItem(
-                                                    index = index,
-                                                    expectedWord = expectedWord,
-                                                    actualWord = text.toString()
-                                                )
-
-                                            )
-                                            if (text.toString() == expectedWord) {
-                                                clickAudioPlayer.start() // Success sound
-                                            }
-                                            else {
-                                                errorAudioPlayer.start() // Success sound
-                                            }
-                                            return true
-                                        }
-                                    }
+                                    seedWordTarget(
+                                        index = index,
+                                        expectedWord = expected,
+                                        onEvent = onEvent,
+                                        onCorrect = onCorrect,
+                                        onWrong = onWrong,
+                                        autoScrollController = autoScrollController
+                                    )
                                 }
                             ),
                         label = label,
-                        isError = actualWord.isNotEmpty() && expectedWord != actualWord,
+                        isError = actual.isNotEmpty() && expected != actual,
                     )
                 }
             }
 
             Spacer(modifier = Modifier.weight(1f))
+
+            // --- Instructions ---
             Text(
-                text = stringResource(if (state.orderCorrected) R.string.empty_string else R.string.tap_drag_a_word),
+                text = stringResource(
+                    if (state.orderCorrected) R.string.empty_string
+                    else R.string.tap_drag_a_word
+                ),
                 style = MaterialTheme.typography.bodyMedium.copy(
                     textAlign = TextAlign.Center,
                     color = Color.Gray
                 )
             )
+
             Spacer(modifier = Modifier.weight(0.1f))
 
+            // --- Shuffled words area ---
             SeedWordsLayout {
-                itemsIndexed(items = state.shuffledSeedWords) { index, (correctIndex, word) ->
+                itemsIndexed(state.shuffledSeedWords) { index, (correctIndex, word) ->
                     if (state.isWordUsedCorrectly(correctIndex, word)) {
                         Box(modifier = Modifier.fillMaxWidth())
                     } else {
@@ -199,10 +210,7 @@ fun YourSeedProveItScreen(
                                         onPress = {
                                             startTransfer(
                                                 DragAndDropTransferData(
-                                                    clipData = ClipData.newPlainText(
-                                                        "text",
-                                                        word
-                                                    ),
+                                                    clipData = ClipData.newPlainText("text", word),
                                                     flags = View.DRAG_FLAG_GLOBAL
                                                 )
                                             )
@@ -218,27 +226,81 @@ fun YourSeedProveItScreen(
                             }
                         )
                     }
-
-
                 }
             }
 
-
+            // --- Action button ---
             LargeButton(
                 onClick = {
                     if (state.orderCorrected) {
                         onNavigate.invoke(UiEffect.Navigate(Route.TopUp))
                     } else {
-                        viewModel.onEvent(YourSeedProveItEvent.OnClear)
+                        onEvent(YourSeedProveItEvent.OnClear)
                     }
-                },
+                }
             ) {
                 Text(
-                    text = stringResource(if (state.orderCorrected) R.string.game_and_sync else R.string.reset_start_over).uppercase(),
+                    text = stringResource(
+                        if (state.orderCorrected) R.string.game_and_sync
+                        else R.string.reset_start_over
+                    ).uppercase(),
                     style = MaterialTheme.typography.labelLarge
                 )
             }
-
         }
+    }
+}
+
+private fun seedWordTarget(
+    index: Int,
+    expectedWord: String,
+    onEvent: (YourSeedProveItEvent) -> Unit,
+    onCorrect: () -> Unit,
+    onWrong: () -> Unit,
+    autoScrollController: AutoScrollController,
+): DragAndDropTarget = object : DragAndDropTarget {
+    override fun onStarted(event: DragAndDropEvent) = autoScrollController.update(event)
+    override fun onEntered(event: DragAndDropEvent) = autoScrollController.update(event)
+    override fun onMoved(event: DragAndDropEvent) = autoScrollController.update(event)
+    override fun onChanged(event: DragAndDropEvent) = autoScrollController.update(event)
+    override fun onExited(event: DragAndDropEvent) = autoScrollController.stop()
+    override fun onEnded(event: DragAndDropEvent) = autoScrollController.stop()
+
+    override fun onDrop(event: DragAndDropEvent): Boolean {
+        autoScrollController.stop()
+        val word = event.toAndroidDragEvent().clipData?.getItemAt(0)?.text?.toString().orEmpty()
+        onEvent(
+            YourSeedProveItEvent.OnDropSeedWordItem(
+                index = index,
+                expectedWord = expectedWord,
+                actualWord = word
+            )
+        )
+        if (word == expectedWord) onCorrect() else onWrong()
+        return true
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun YourSeedProveItScreenPreview() {
+    BrainwalletAppTheme(appSetting = AppSetting(isSystemInDarkTheme())) {
+        val dummyState = YourSeedProveItState(
+            correctSeedWords = mapOf(
+                0 to SeedWordItem(expected = "apple", actual = "apple"),
+                1 to SeedWordItem(expected = "banana", actual = "mango"), // wrong
+                2 to SeedWordItem(expected = "cherry", actual = "")
+            ),
+            shuffledSeedWords = listOf(
+                0 to "apple",
+                1 to "mango",
+                2 to "cherry"
+            ),
+            orderCorrected = false
+        )
+
+        YourSeedProveItScreen(
+            state = dummyState
+        )
     }
 }


### PR DESCRIPTION
## 📱 Description
Fix issue When using the drag-and-drop feature for wallet pass phrases, users on small-screen devices (or when using split-screen mode) cannot place phrases into the last row. The issue occurs because the last row is rendered outside of the visible screen area, making it impossible to drag items into it.

## Platform
- [x] Android
- [ ] iOS
- [ ] Games-Unity
- [ ] DevOps (AWS)
- [ ] Website
- [ ] C/Golang 

## 🎯 Type of Change
<!-- Mark the relevant option with an [x] -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement

## 📋 Changes
This commit refactors the `YourSeedProveItScreen` composable for better readability and structure. Key changes include:
- Separated the main screen composable into a private `YourSeedProveItScreen` and a public wrapper.
- Introduced `AutoScrollController` to enable auto-scrolling when dragging seed words near the top or bottom edges of the scrollable area.
- Integrated the `AutoScrollController` into the drag-and-drop target logic.
- Added `@PreviewLightDark` for better previewing in different themes.
- Minor cleanup of layout values and event handling.

### 🔗 Related Issues
- Fixes https://github.com/gruntsoftware/internal/issues/213

## 🧪 Tests Status
- [x] Tests ran successfully locally?

## 📸 Screenshots/Videos
| Before | After |
|--------|-------|
|![before](https://github.com/user-attachments/assets/d96047c0-7799-46c5-bd99-38d4c78199a4)|![after](https://github.com/user-attachments/assets/fe3ef98c-a0aa-43dd-bcfe-7174dcf8e3dd)|

## 🎯 Reviewers
<!-- Tag specific reviewers or teams -->
@kcw-grunt, @josikie
