### PR TITLE
Fix(#227): Crash when launching MoonPay Widget

### DIFF
--- a/app/src/main/java/com/brainwallet/navigation/LegacyNavigation.kt
+++ b/app/src/main/java/com/brainwallet/navigation/LegacyNavigation.kt
@@ -1,25 +1,13 @@
 package com.brainwallet.navigation
 
 import android.app.Activity
-import android.app.ProgressDialog
 import android.content.Context
 import android.content.Intent
-import android.widget.Toast
-import androidx.browser.customtabs.CustomTabsIntent
-import androidx.core.net.toUri
-import com.brainwallet.BuildConfig
 import com.brainwallet.R
-import com.brainwallet.data.repository.LtcRepository
-import com.brainwallet.di.AppModule.getKoinInstance
 import com.brainwallet.presenter.activities.BreadActivity
 import com.brainwallet.ui.BrainwalletActivity
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 import com.google.firebase.analytics.FirebaseAnalytics
-
 
 //provide old navigation using intent activity
 object LegacyNavigation {
@@ -67,52 +55,4 @@ object LegacyNavigation {
     ) = BrainwalletActivity.createIntent(context, destination).also {
         context.startActivity(it)
     }
-
-    @JvmOverloads
-    @JvmStatic
-    fun showMoonPayWidget(
-        context: Context,
-        params: Map<String, String> = mapOf(),
-        isDarkMode: Boolean = true,
-    ) {
-        val ltcRepository: LtcRepository = getKoinInstance()
-        val progressDialog = ProgressDialog(context).apply {
-            setMessage(context.getString(R.string.loading))
-            setCancelable(false)
-            show()
-        }
-
-        CoroutineScope(Dispatchers.Main).launch {
-            try {
-                val result = withContext(Dispatchers.IO) {
-                    ltcRepository.fetchMoonpaySignedUrl(
-                        params = params.toMutableMap().apply {
-                            put("theme", if (isDarkMode) "dark" else "light")
-                        }
-                    )
-                }
-
-                val widgetUri = result.toUri().buildUpon()
-                    .apply {
-                        if (BuildConfig.DEBUG) {
-                            authority("buy-sandbox.moonpay.com")//replace base url from buy.moonpay.com
-                        }
-                    }
-                    .build()
-                val intent = CustomTabsIntent.Builder()
-                    .setColorScheme(if (isDarkMode) CustomTabsIntent.COLOR_SCHEME_DARK else CustomTabsIntent.COLOR_SCHEME_LIGHT)
-                    .build()
-                intent.launchUrl(context, widgetUri)
-            } catch (e: Exception) {
-                Toast.makeText(
-                    context,
-                    "Failed to load: ${e.message}, please try again later",
-                    Toast.LENGTH_LONG
-                ).show()
-            } finally {
-                progressDialog.dismiss()
-            }
-        }
-    }
-
 }

--- a/app/src/main/java/com/brainwallet/navigation/MoonPayWidgeLauncher.kt
+++ b/app/src/main/java/com/brainwallet/navigation/MoonPayWidgeLauncher.kt
@@ -1,0 +1,103 @@
+package com.brainwallet.navigation
+
+import android.net.Uri
+import android.widget.Toast
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.net.toUri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.brainwallet.BuildConfig
+import com.brainwallet.data.repository.LtcRepository
+import com.brainwallet.data.repository.SettingRepository
+import com.brainwallet.ui.composable.LoadingDialog
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.koin.android.annotation.KoinViewModel
+import org.koin.compose.viewmodel.koinViewModel
+
+@KoinViewModel
+class MoonPayWidgetLauncherViewModel(
+    private val settingRepository: SettingRepository,
+    private val ltcRepository: LtcRepository,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : ViewModel() {
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading = _isLoading.asStateFlow()
+
+    private val _result = Channel<Result<Pair<Boolean, Uri>>>()
+    val result = _result.receiveAsFlow()
+
+    fun launch(params: Map<String, String>) {
+        _isLoading.update { true }
+        viewModelScope.launch(ioDispatcher) {
+            val isDarkMode = settingRepository.isDarkMode()
+            _result.send(ltcRepository.runCatching {
+                val result = ltcRepository.fetchMoonpaySignedUrl(
+                    params = params.toMutableMap().apply {
+                        put("theme", if (isDarkMode) "dark" else "light")
+                    }
+                )
+                isDarkMode to result.toUri().buildUpon()
+                    .apply {
+                        if (BuildConfig.DEBUG) {
+                            authority("buy-sandbox.moonpay.com")//replace base url from buy.moonpay.com
+                        }
+                    }
+                    .build()
+            })
+            _isLoading.update { false }
+        }
+    }
+}
+
+@Composable
+fun MoonPayWidgetLauncher(
+    modifier: Modifier = Modifier,
+    viewModel: MoonPayWidgetLauncherViewModel = koinViewModel(),
+    onResult: () -> Unit = {}
+) {
+    val context = LocalContext.current
+    val isLoading by viewModel.isLoading.collectAsState()
+
+    AnimatedVisibility(isLoading, modifier = modifier) {
+        LoadingDialog()
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.result.collect { result ->
+            result.fold(
+                onSuccess = { (isDarkMode, uri) ->
+                    val intent = CustomTabsIntent.Builder()
+                        .setColorScheme(
+                            if (isDarkMode) CustomTabsIntent.COLOR_SCHEME_DARK
+                            else CustomTabsIntent.COLOR_SCHEME_LIGHT
+                        )
+                        .build()
+                    intent.launchUrl(context, uri)
+                },
+                onFailure = { e ->
+                    Toast.makeText(
+                        context,
+                        "Failed to load: ${e.message}, please try again later",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            )
+            onResult.invoke()
+        }
+    }
+}

--- a/app/src/main/java/com/brainwallet/ui/screens/buylitecoin/BuyLitecoinScreen.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/buylitecoin/BuyLitecoinScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Done
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -26,22 +25,22 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.brainwallet.R
-import com.brainwallet.navigation.LegacyNavigation
+import com.brainwallet.navigation.MoonPayWidgetLauncher
+import com.brainwallet.navigation.MoonPayWidgetLauncherViewModel
 import com.brainwallet.navigation.OnNavigate
 import com.brainwallet.navigation.UiEffect
 import com.brainwallet.ui.composable.BrainwalletScaffold
 import com.brainwallet.ui.composable.BrainwalletTopAppBar
 import com.brainwallet.ui.composable.LargeButton
-import com.brainwallet.ui.composable.LoadingDialog
-import com.brainwallet.ui.screens.home.receive.ReceiveDialogEvent
 import com.brainwallet.ui.theme.BrainwalletTheme
-import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
 
 //TODO: wip
 @Composable
 fun BuyLitecoinScreen(
     onNavigate: OnNavigate,
-    viewModel: BuyLitecoinViewModel = koinInject()
+    viewModel: BuyLitecoinViewModel = koinViewModel(),
+    moonPayWidgetLauncherViewModel: MoonPayWidgetLauncherViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsState()
     val loadingState by viewModel.loadingState.collectAsState()
@@ -148,21 +147,20 @@ fun BuyLitecoinScreen(
                 modifier = Modifier.align(Alignment.BottomCenter),
                 enabled = loadingState.visible.not(),
                 onClick = {
-                    //open bread activity first then open moonpay widget
-                    LegacyNavigation.restartBreadActivity(context)
-                    LegacyNavigation.showMoonPayWidget(
-                        context = context,
+                    moonPayWidgetLauncherViewModel.launch(
                         params = mapOf(
                             "baseCurrencyCode" to appSetting.currency.code,
                             "baseCurrencyAmount" to state.fiatAmount.toString(),
                             "language" to appSetting.languageCode,
                             "walletAddress" to state.address
-                        )
+                        ),
+
                     )
                 }
             ) {
                 Text(stringResource(R.string.buy_litecoin_button_moonpay))
             }
         }
+        MoonPayWidgetLauncher(viewModel = moonPayWidgetLauncherViewModel)
     }
 }

--- a/app/src/main/java/com/brainwallet/ui/screens/home/receive/ReceiveDialog.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/home/receive/ReceiveDialog.kt
@@ -63,7 +63,8 @@ import androidx.fragment.app.FragmentManager
 import com.brainwallet.R
 import com.brainwallet.data.model.getFormattedText
 import com.brainwallet.data.model.isCustom
-import com.brainwallet.navigation.LegacyNavigation
+import com.brainwallet.navigation.MoonPayWidgetLauncher
+import com.brainwallet.navigation.MoonPayWidgetLauncherViewModel
 import com.brainwallet.navigation.UiEffect
 import com.brainwallet.ui.composable.MoonpayBuyButton
 import com.brainwallet.ui.composable.VerticalWheelPicker
@@ -77,13 +78,14 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import org.koin.android.ext.android.inject
-import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
 import timber.log.Timber
 
 @Composable
 fun ReceiveDialog(
     onDismissRequest: () -> Unit,
-    viewModel: ReceiveDialogViewModel = koinInject()
+    viewModel: ReceiveDialogViewModel = koinViewModel(),
+    moonPayWidgetLauncherViewModel: MoonPayWidgetLauncherViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsState()
     val loadingState by viewModel.loadingState.collectAsState()
@@ -369,24 +371,23 @@ fun ReceiveDialog(
                     //todo: revisit this later
                     //viewModel.onEvent(ReceiveDialogEvent.OnMoonpayButtonClick)
 
-                    LegacyNavigation.showMoonPayWidget(
-                        context = context,
+                    moonPayWidgetLauncherViewModel.launch(
                         params = mapOf(
                             "baseCurrencyCode" to state.selectedFiatCurrency.code,
                             "baseCurrencyAmount" to state.fiatAmount.toString(),
                             "language" to appSetting.languageCode,
                             "walletAddress" to state.address,
                         ),
-                        isDarkMode = appSetting.isDarkMode
                     )
-                    onDismissRequest.invoke()
                 },
             )
 
 //            }
         }
-
-
+        MoonPayWidgetLauncher(
+            viewModel = moonPayWidgetLauncherViewModel,
+            onResult = onDismissRequest
+        )
     }
 }
 


### PR DESCRIPTION
## 📱 Description
This PR fixes a crash when launching the MoonPay Widget by refactoring the integration into a dedicated Composable with proper state and lifecycle handling.

### 🛑 Root Cause

The crash occurred because the old implementation used a `ProgressDialog` tied to an `Activity` context that was restarted during navigation. When the code attempted to dismiss the dialog after the `Activity` was destroyed, it triggered `WindowManager$BadTokenException: DecorView not attached to window manager`. This also introduced code smell due to deprecated APIs, tight coupling between navigation and UI state, and manual lifecycle management.

### ✅ Proposed Solution

The fix refactors the MoonPay widget integration into a dedicated Composable (`MoonPayWidgetLauncher`) with its own ViewModel. This removes reliance on `ProgressDialog` and instead leverages lifecycle-aware state handling and Custom Tabs for launching MoonPay. By eliminating manual dialog management and decoupling navigation logic from UI state, the solution prevents crashes, aligns with modern Compose practices, and removes deprecated, lifecycle-unsafe patterns.

## Platform
- [x] Android
- [ ] iOS
- [ ] Games-Unity
- [ ] DevOps (AWS)
- [ ] Website
- [ ] C/Golang 

## 🎯 Type of Change
<!-- Mark the relevant option with an [x] -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement

## 📋 Changes
- Added `MoonPayWidgetLauncher.kt` with Composable and ViewModel for managing signed URL fetch and Custom Tab launch.
- Ensures loading state covers the whole screen, preventing UI crashes.
- Removed legacy static method `LegacyNavigation.showMoonPayWidget`.
- Updated `ReceiveDialog.kt` and `BuyLitecoinScreen.kt` to use the new Composable.
- Minor cleanup in `LegacyNavigation.kt`.

### 🔗 Related Issues
<!-- Link any related issues using "Fixes #issue_number" or "Closes #issue_number" -->
- Fixes https://github.com/gruntsoftware/internal/issues/227

## 🧪 Tests Status
- [x] Tests ran successfully locally?
- [ ] Added more tests? How many? **I can't test the viewmodel, but i already setup viewmodel test environment at https://github.com/gruntsoftware/android/pull/122 please take a look**
- [ ] Code coverage percentage of the codebase: __%

## 📸 Screenshots/Videos
N/A - The behaviour is looks the same

## 🎯 Reviewers
<!-- Tag specific reviewers or teams -->
@kcw-grunt, @josikie
