### PR TITLE
fix(#223): fix issue on test environment SLF4J + agent warnings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -245,12 +245,14 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.turbine)
+    testImplementation(libs.slf4j.android)
     testImplementation(libs.kotlinx.coroutines.tests)
 
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.bundles.androidx.compose.ui.test)
     androidTestImplementation(libs.bundles.android.test)
     androidTestImplementation(libs.fastlane.screengrab)
+    androidTestImplementation(libs.slf4j.android)
 }
 
 val ktlintCheck by tasks.registering(JavaExec::class) {
@@ -283,4 +285,8 @@ tasks.register<JavaExec>("ktlintFormat") {
         "**.kts",
         "!**/build/**",
     )
+}
+
+tasks.withType<Test> {
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ koin-annotation-bom = "2.1.0"
 ksp = "2.0.0-1.0.24"
 turbine = "1.2.1"
 coroutines = "1.10.2"
+slf4j = "1.7.36"
 
 [libraries]
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core-ktx" }
@@ -122,6 +123,7 @@ koin-annotation-compiler = { module = "io.insert-koin:koin-ksp-compiler", versio
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-tests = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+slf4j-android = { module = "org.slf4j:slf4j-android", version.ref = "slf4j" }
 
 [bundles]
 androidx-lifecycle = ["androidx-lifecycle-runtime", "androidx-lifecycle-viewmodel", "androidx-lifecycle-viewmodel-compose"]


### PR DESCRIPTION

## 📱 Description
This PR fixes SLF4J and Byte Buddy agent warnings that occur when running tests in Android Studio or via Gradle.
These warnings do not affect production builds or the APK. They are specific to the test environment only.
- SLF4J warnings happen because no logging backend was configured; adding slf4j-android resolves this by routing logs to Logcat.
- Byte Buddy agent warnings occur due to dynamic Java agent loading during tests; configuring JVM args (-XX:+EnableDynamicAgentLoading) suppresses the warning.
ℹ️ Note on EnableDynamicAgentLoading
Suppressing the warning by enabling dynamic agent loading is safe in our case. It only affects the test JVM environment and has no impact on runtime behavior or production APKs. Disabling the suppression would simply keep printing the warning, but still would not break our tests.

## Platform

- [x] Android
- [ ] iOS
- [ ] Games-Unity
- [ ] DevOps (AWS)
- [ ] Website
- [ ] C/Golang 

## 🎯 Type of Change
<!-- Mark the relevant option with an [x] -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement

## 📋 Changes
- Added `slf4j-android` as a test dependency to provide a proper SLF4J binding and avoid "StaticLoggerBinder" warnings.
- Configured JVM args for Gradle test tasks to enable dynamic agent loading, suppressing Byte Buddy agent warnings during test runs.

### 🔗 Related Issues
<!-- Link any related issues using "Fixes #issue_number" or "Closes #issue_number" -->
- Fixes https://github.com/gruntsoftware/internal/issues/223


## 🧪 Tests Status
- [x] Tests ran successfully locally?
- [ ] Added more tests? How many?
- [ ] Code coverage percentage of the codebase: __%

## 📸 Screenshots/Videos
<!-- Add screenshots or screen recordings of UI changes -->
<!-- Use the format below for before/after comparisons -->

| Before | After |
|--------|-------|
|<img width="1305" height="779" alt="{A58DA21F-C1E3-40A7-8866-414471BCE8BE}" src="https://github.com/user-attachments/assets/d63300be-63a3-432b-a02a-b628f255f7b8" />|<img width="1305" height="783" alt="{687724C6-ED3C-45A8-AF9A-4D6B6EEAAED7}" src="https://github.com/user-attachments/assets/f89628c2-8ba6-4f26-a23c-14397ef72b55" />|

## 🎯 Reviewers
<!-- Tag specific reviewers or teams -->
@kcw-grunt, @josikie
