### PR TITLE
fix(#226): android test failure on RecoverWalletScreenGrabsTest

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,6 +71,13 @@ android {
             firebaseCrashlytics {
                 nativeSymbolUploadEnabled = true
             }
+            buildConfigField("String[]", "SCREENGRAB_PAPERKEY",
+                "new String[] {${
+                    localProperties.getProperty("SCREENGRAB_PAPERKEY", "")
+                        .split(" ")
+                        .joinToString { "\"$it\"" }
+                }}"
+            )
         }
 
         val release by getting {
@@ -125,13 +132,6 @@ android {
             applicationId = "ltd.grunt.brainwallet.screengrab"
             versionNameSuffix = "-screengrab"
             resValue("string", "app_name", "Brainwallet (screengrab)")
-            buildConfigField("String[]", "SCREENGRAB_PAPERKEY",
-                "new String[] {${
-                    localProperties.getProperty("SCREENGRAB_PAPERKEY", "")
-                        .split(" ")
-                        .joinToString { "\"$it\"" }
-                }}"
-            )
 
             externalNativeBuild {
                 cmake {

--- a/app/src/screengrab/kotlin/com/brainwallet/BrainwalletScreengrabApp.kt
+++ b/app/src/screengrab/kotlin/com/brainwallet/BrainwalletScreengrabApp.kt
@@ -1,9 +1,6 @@
 package com.brainwallet
 
 import com.brainwallet.data.source.RemoteConfigSource
-import com.brainwallet.di.appModule
-import com.brainwallet.di.dataModule
-import com.brainwallet.di.viewModelModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.GlobalContext.startKoin


### PR DESCRIPTION
## 📱 Description
Fix issue crash on screengrab ui test, caused by invalid BuildConfig

## Platform
- [x] Android
- [ ] iOS
- [ ] Games-Unity
- [ ] DevOps (AWS)
- [ ] Website
- [ ] C/Golang 

## 🎯 Type of Change
<!-- Mark the relevant option with an [x] -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement

## 📋 Changes
Move SCREENGRAB_PAPERKEY build config to debug build type

The `SCREENGRAB_PAPERKEY` build configuration field, used for screengrab tests, was previously defined in both the `debug` and `screengrab` build types.

This commit moves the definition solely to the `debug` build type, as the `screengrab` build type inherits from `debug` and thus already has access to this field.

Additionally, unused imports were removed from `BrainwalletScreengrabApp.kt`.

### 🔗 Related Issues
<!-- Link any related issues using "Fixes #issue_number" or "Closes #issue_number" -->
- Fixes https://github.com/gruntsoftware/internal/issues/226

## 🧪 Tests Status
- [x] Tests ran successfully locally?
- [ ] Added more tests? How many?
- [ ] Code coverage percentage of the codebase: __%

## 📸 Screenshots/Videos
N/A Behaviour is identical

## 🎯 Reviewers
<!-- Tag specific reviewers or teams -->
@kcw-grunt, @josikie
