### PR TITLE
feat(#234): Implement language-specific Firebase messaging topics

### DIFF
--- a/app/src/main/java/com/brainwallet/BrainwalletApp.kt
+++ b/app/src/main/java/com/brainwallet/BrainwalletApp.kt
@@ -8,6 +8,7 @@ import android.content.res.Resources
 import com.appsflyer.AppsFlyerLib
 import com.brainwallet.data.source.RemoteConfigSource
 import com.brainwallet.di.AppModule
+import com.brainwallet.domain.MessagingTopicUseCase
 import com.brainwallet.notification.NotificationHandler
 import com.brainwallet.presenter.activities.util.BRActivity
 import com.brainwallet.presenter.entities.ServiceItems
@@ -32,6 +33,7 @@ open class BrainwalletApp : Application() {
 
     private val remoteConfigSource: RemoteConfigSource by inject()
     private val notificationHandler: NotificationHandler by inject()
+    private val messagingTopicHandler: MessagingTopicUseCase by inject()
 
     override fun onCreate() {
         super.onCreate()
@@ -80,6 +82,7 @@ open class BrainwalletApp : Application() {
             modules(AppModule.dataModule, AppModule.module)
         }
         thread { remoteConfigSource.initialize() }
+        thread { messagingTopicHandler.initialize() }
     }
 
 //    override fun attachBaseContext(base: Context) {

--- a/app/src/main/java/com/brainwallet/data/repository/MessagingTopicRepository.kt
+++ b/app/src/main/java/com/brainwallet/data/repository/MessagingTopicRepository.kt
@@ -1,0 +1,20 @@
+package com.brainwallet.data.repository
+
+import com.brainwallet.data.model.Language
+import com.brainwallet.data.source.MessagingTopicDataSource
+import org.koin.core.annotation.Single
+
+@Single
+class MessagingTopicRepository(
+    private val settingRepository: SettingRepository,
+    private val topicDataSource: MessagingTopicDataSource
+) {
+    fun getCurrentTopics(): List<String> {
+        val currentLanguage = settingRepository.getCurrentLanguage()
+        return topicDataSource.getTopicsByLanguageCode(currentLanguage.code)
+    }
+
+    fun getTopicsByLanguage(language: Language): List<String> {
+        return topicDataSource.getTopicsByLanguageCode(language.code)
+    }
+}

--- a/app/src/main/java/com/brainwallet/data/source/MessagingTopicDataSource.kt
+++ b/app/src/main/java/com/brainwallet/data/source/MessagingTopicDataSource.kt
@@ -1,0 +1,29 @@
+package com.brainwallet.data.source
+
+import com.brainwallet.data.model.Language
+import org.koin.core.annotation.Single
+
+@Single
+class MessagingTopicDataSource(
+    private val supportedLanguages: List<Language> = Language.entries,
+    private val defaultLanguage: Language = Language.ENGLISH
+) {
+    fun getTopicsByLanguageCode(languageCode: String): List<String> {
+        val baseLanguageCode = getBaseLanguageCode(languageCode)
+        return listOf(
+            "initial_$baseLanguageCode",
+            "news_$baseLanguageCode",
+            "promo_$baseLanguageCode",
+            "warn_$baseLanguageCode"
+        )
+    }
+
+    private fun getBaseLanguageCode(languageCode: String): String {
+        val normalizedLanguageCode = languageCode.split("_", "-").first().lowercase()
+        val targetLanguage = supportedLanguages.find { 
+            it.code.split("-").first().lowercase() == normalizedLanguageCode 
+        } ?: defaultLanguage
+        
+        return targetLanguage.code.split("-").first().lowercase()
+    }
+}

--- a/app/src/main/java/com/brainwallet/domain/LanguageSwitcherUseCase.kt
+++ b/app/src/main/java/com/brainwallet/domain/LanguageSwitcherUseCase.kt
@@ -1,0 +1,16 @@
+package com.brainwallet.domain
+
+import com.brainwallet.data.model.Language
+import com.brainwallet.data.repository.SettingRepository
+import org.koin.core.annotation.Single
+
+@Single
+class LanguageSwitcherUseCase(
+    private val settingRepository: SettingRepository,
+    private val messagingTopicUseCase: MessagingTopicUseCase
+) {
+    fun switchLanguage(newLanguage: Language) {
+        messagingTopicUseCase.subscribeByLanguage(newLanguage)
+        settingRepository.updateCurrentLanguage(newLanguage.code)
+    }
+}

--- a/app/src/main/java/com/brainwallet/domain/MessagingTopicUseCase.kt
+++ b/app/src/main/java/com/brainwallet/domain/MessagingTopicUseCase.kt
@@ -1,0 +1,36 @@
+package com.brainwallet.domain
+
+import com.brainwallet.data.model.Language
+import com.brainwallet.data.repository.MessagingTopicRepository
+import com.google.firebase.messaging.FirebaseMessaging
+import org.koin.core.annotation.Single
+
+@Single
+class MessagingTopicUseCase(
+    private val messagingTopicRepository: MessagingTopicRepository,
+    private val firebaseMessaging: FirebaseMessaging = FirebaseMessaging.getInstance()
+) {
+    fun initialize() {
+        val topics = messagingTopicRepository.getCurrentTopics()
+        subscribeToTopics(topics)
+    }
+
+    fun subscribeByLanguage(newLanguage: Language) {
+        val currentTopics = messagingTopicRepository.getCurrentTopics()
+        unsubscribeFromTopics(currentTopics)
+        val newTopics = messagingTopicRepository.getTopicsByLanguage(newLanguage)
+        subscribeToTopics(newTopics)
+    }
+
+    private fun subscribeToTopics(topics: List<String>) {
+        topics.forEach { topic ->
+            firebaseMessaging.subscribeToTopic(topic)
+        }
+    }
+
+    private fun unsubscribeFromTopics(topics: List<String>) {
+        topics.forEach { topic ->
+            firebaseMessaging.unsubscribeFromTopic(topic)
+        }
+    }
+}

--- a/app/src/main/java/com/brainwallet/presenter/language/ChangeLanguageBottomSheet.kt
+++ b/app/src/main/java/com/brainwallet/presenter/language/ChangeLanguageBottomSheet.kt
@@ -10,6 +10,7 @@ import com.brainwallet.R
 import com.brainwallet.data.model.Language
 import com.brainwallet.data.repository.SettingRepository
 import com.brainwallet.databinding.ChangeLanguageBottomSheetBinding
+import com.brainwallet.domain.LanguageSwitcherUseCase
 import com.brainwallet.navigation.LegacyNavigation
 import com.brainwallet.tools.util.Utils
 import com.brainwallet.tools.util.getString
@@ -23,6 +24,7 @@ class ChangeLanguageBottomSheet : RoundedBottomSheetDialogFragment() {
     lateinit var binding: ChangeLanguageBottomSheetBinding
 
     private val settingRepository by inject<SettingRepository>()
+    private val languageSwitcherUseCase by inject<LanguageSwitcherUseCase>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -65,7 +67,7 @@ class ChangeLanguageBottomSheet : RoundedBottomSheetDialogFragment() {
 
         binding.okButton.setOnClickListener {
             if (settingRepository.getCurrentLanguage() != adapter.selectedLanguage()) {
-                settingRepository.updateCurrentLanguage(adapter.selectedLanguage().code)
+                languageSwitcherUseCase.switchLanguage(adapter.selectedLanguage())
                 LegacyNavigation.openComposeScreen(
                     context = requireContext(),
                 )

--- a/app/src/main/java/com/brainwallet/ui/screens/home/SettingsViewModel.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/home/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import com.brainwallet.data.model.Language
 import com.brainwallet.data.model.toFeeOptions
 import com.brainwallet.data.repository.LtcRepository
 import com.brainwallet.data.repository.SettingRepository
+import com.brainwallet.domain.LanguageSwitcherUseCase
 import com.brainwallet.tools.manager.FeeManager
 import com.brainwallet.ui.BrainwalletViewModel
 import com.brainwallet.util.EventBus
@@ -27,6 +28,7 @@ import org.koin.android.annotation.KoinViewModel
 @KoinViewModel
 class SettingsViewModel(
     private val settingRepository: SettingRepository,
+    private val languageSwitcherUseCase: LanguageSwitcherUseCase,
     private val ltcRepository: LtcRepository
 ) : BrainwalletViewModel<SettingsEvent>() {
 
@@ -127,7 +129,7 @@ class SettingsViewModel(
                 )
             }.let {
                 viewModelScope.launch {
-                    settingRepository.save(appSetting.value.copy(languageCode = event.language.code))
+                    languageSwitcherUseCase.switchLanguage(event.language)
                     AppCompatDelegate.setApplicationLocales(
                         LocaleListCompat.forLanguageTags(
                             event.language.code

--- a/app/src/test/java/com/brainwallet/data/repository/MessagingTopicRepositoryTest.kt
+++ b/app/src/test/java/com/brainwallet/data/repository/MessagingTopicRepositoryTest.kt
@@ -1,0 +1,71 @@
+package com.brainwallet.data.repository
+
+import com.brainwallet.data.model.Language
+import com.brainwallet.data.source.MessagingTopicDataSource
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class MessagingTopicRepositoryTest {
+
+    @MockK
+    private lateinit var mockSettingRepository: SettingRepository
+
+    @MockK
+    private lateinit var mockTopicDataSource: MessagingTopicDataSource
+
+    private lateinit var repository: MessagingTopicRepository
+
+    private lateinit var fakeIndonesianTopics: List<String>
+    private lateinit var fakeEnglishTopics: List<String>
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        fakeIndonesianTopics = listOf("initial_in", "news_in", "promo_in", "warn_in")
+        fakeEnglishTopics = listOf("initial_en", "news_en", "promo_en", "warn_en")
+        repository = MessagingTopicRepository(mockSettingRepository, mockTopicDataSource)
+    }
+
+    @Test
+    fun `given current language code is in when getCurrentTopics called then repository should return topics for Indonesian`() {
+        every { mockSettingRepository.getCurrentLanguage().code } returns "in"
+        every { mockTopicDataSource.getTopicsByLanguageCode("in") } returns fakeIndonesianTopics
+
+        val result = repository.getCurrentTopics()
+
+        assert(result == fakeIndonesianTopics) {
+            "Expected repository to return topics for Indonesian but got $result"
+        }
+        verify(exactly = 1) { mockTopicDataSource.getTopicsByLanguageCode("in") }
+    }
+
+    @Test
+    fun `given language object when getTopicsByLanguage called then repository should return topics for that language`() {
+        val language = Language.INDONESIAN
+        every { mockTopicDataSource.getTopicsByLanguageCode(language.code) } returns fakeIndonesianTopics
+
+        val result = repository.getTopicsByLanguage(language)
+
+        assert(result == fakeIndonesianTopics) {
+            "Expected repository to return topics for Indonesian language but got $result"
+        }
+        verify(exactly = 1) { mockTopicDataSource.getTopicsByLanguageCode(language.code) }
+    }
+
+    @Test
+    fun `given English language when getTopicsByLanguage called then repository should return English topics`() {
+        val language = Language.ENGLISH
+        every { mockTopicDataSource.getTopicsByLanguageCode(language.code) } returns fakeEnglishTopics
+
+        val result = repository.getTopicsByLanguage(language)
+
+        assert(result == fakeEnglishTopics) {
+            "Expected repository to return topics for English language but got $result"
+        }
+        verify(exactly = 1) { mockTopicDataSource.getTopicsByLanguageCode(language.code) }
+    }
+}

--- a/app/src/test/java/com/brainwallet/data/source/MessagingTopicDataSourceTest.kt
+++ b/app/src/test/java/com/brainwallet/data/source/MessagingTopicDataSourceTest.kt
@@ -1,0 +1,108 @@
+package com.brainwallet.data.source
+
+import com.brainwallet.data.model.Language
+import org.junit.Before
+import org.junit.Test
+
+class MessagingTopicDataSourceTest {
+    private lateinit var dataSource: MessagingTopicDataSource
+
+    @Before
+    fun setUp() {
+        dataSource = MessagingTopicDataSource()
+    }
+
+    @Test
+    fun `given locale with underscore when getTopicsByLanguageCode called then it should extract base language only`() {
+        val result = dataSource.getTopicsByLanguageCode("fr_FR")
+
+        val expectedTopics = listOf("initial_fr", "news_fr", "promo_fr", "warn_fr")
+        assert(result == expectedTopics) {
+            "Expected topics for French language from 'fr_FR' but got $result"
+        }
+    }
+
+    @Test
+    fun `given locale with hyphen when getTopicsByLanguageCode called then it should extract base language only`() {
+        val result = dataSource.getTopicsByLanguageCode("zh-CN")
+
+        val expectedTopics = listOf("initial_zh", "news_zh", "promo_zh", "warn_zh")
+        assert(result == expectedTopics) {
+            "Expected topics for Chinese language from 'zh-CN' but got $result"
+        }
+    }
+
+    @Test
+    fun `given uppercase language code when getTopicsByLanguageCode called then it should normalize to lowercase`() {
+        val result = dataSource.getTopicsByLanguageCode("FR")
+
+        val expectedTopics = listOf("initial_fr", "news_fr", "promo_fr", "warn_fr")
+        assert(result == expectedTopics) {
+            "Expected topics for French language from uppercase 'FR' but got $result"
+        }
+    }
+
+    @Test
+    fun `given mixed case locale when getTopicsByLanguageCode called then it should normalize to lowercase base`() {
+        val result = dataSource.getTopicsByLanguageCode("Es_ES")
+
+        val expectedTopics = listOf("initial_es", "news_es", "promo_es", "warn_es")
+        assert(result == expectedTopics) {
+            "Expected topics for Spanish language from 'Es_ES' but got $result"
+        }
+    }
+
+    @Test
+    fun `given empty string when getTopicsByLanguageCode called then it should default to English`() {
+        val result = dataSource.getTopicsByLanguageCode("")
+
+        val expectedTopics = listOf("initial_en", "news_en", "promo_en", "warn_en")
+        assert(result == expectedTopics) {
+            "Expected topics to default to English for empty string but got $result"
+        }
+    }
+
+    @Test
+    fun `given unsupported language code when getTopicsByLanguageCode called then it should default to English`() {
+        val result = dataSource.getTopicsByLanguageCode("unsupported")
+
+        val expectedTopics = listOf("initial_en", "news_en", "promo_en", "warn_en")
+        assert(result == expectedTopics) {
+            "Expected topics to default to English for unsupported language but got $result"
+        }
+    }
+
+    @Test
+    fun `given all supported languages when getTopicsByLanguageCode called then it should return correct base language topics`() {
+        val testCases = mapOf(
+            "en" to "en",
+            "es" to "es", 
+            "in" to "in",
+            "ar" to "ar",
+            "uk" to "uk",
+            "ru" to "ru",
+            "pt" to "pt",
+            "hi" to "hi",
+            "de" to "de",
+            "fa" to "fa",
+            "pa" to "pa",
+            "pl" to "pl",
+            "ko" to "ko",
+            "fr" to "fr",
+            "zh-TW" to "zh",
+            "zh-CN" to "zh",
+            "tr" to "tr",
+            "ja" to "ja",
+            "it" to "it",
+            "sv" to "sv"
+        )
+
+        testCases.forEach { (input, expectedBase) ->
+            val result = dataSource.getTopicsByLanguageCode(input)
+            val expectedTopics = listOf("initial_$expectedBase", "news_$expectedBase", "promo_$expectedBase", "warn_$expectedBase")
+            assert(result == expectedTopics) {
+                "Expected topics for '$input' to have base '$expectedBase' but got $result"
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/brainwallet/domain/LanguageSwitcherUseCaseTest.kt
+++ b/app/src/test/java/com/brainwallet/domain/LanguageSwitcherUseCaseTest.kt
@@ -1,0 +1,39 @@
+package com.brainwallet.domain
+
+import com.brainwallet.data.model.Language
+import com.brainwallet.data.repository.SettingRepository
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import io.mockk.verifyOrder
+import org.junit.Before
+import org.junit.Test
+
+class LanguageSwitcherUseCaseTest {
+
+    private lateinit var useCase: LanguageSwitcherUseCase
+
+    @MockK
+    private lateinit var mockSettingRepository: SettingRepository
+
+    @MockK
+    private lateinit var mockMessagingTopicUseCase: MessagingTopicUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        useCase = LanguageSwitcherUseCase(mockSettingRepository, mockMessagingTopicUseCase)
+    }
+
+    @Test
+    fun `given new language when switchLanguage called then it should subscribe by language and update current language`() {
+        val newLanguage = Language.FRENCH
+
+        useCase.switchLanguage(newLanguage)
+
+        // Order is important to make old subscribed language still valid
+        verifyOrder {
+            mockMessagingTopicUseCase.subscribeByLanguage(newLanguage)
+            mockSettingRepository.updateCurrentLanguage(newLanguage.code)
+        }
+    }
+}

--- a/app/src/test/java/com/brainwallet/domain/MessagingTopicUseCaseTest.kt
+++ b/app/src/test/java/com/brainwallet/domain/MessagingTopicUseCaseTest.kt
@@ -1,0 +1,66 @@
+package com.brainwallet.domain
+
+import com.brainwallet.data.model.Language
+import com.brainwallet.data.repository.MessagingTopicRepository
+import com.google.firebase.messaging.FirebaseMessaging
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class MessagingTopicUseCaseTest {
+
+    private lateinit var useCase: MessagingTopicUseCase
+
+    @MockK
+    private lateinit var mockRepository: MessagingTopicRepository
+
+    @RelaxedMockK
+    private lateinit var mockFirebaseMessaging: FirebaseMessaging
+    private lateinit var currentTopics: List<String>
+    private lateinit var newTopics: List<String>
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        currentTopics = listOf("initial_en", "news_en", "promo_en", "warn_en")
+        newTopics = listOf("initial_fr", "news_fr", "promo_fr", "warn_fr")
+
+        useCase = MessagingTopicUseCase(mockRepository, mockFirebaseMessaging)
+    }
+
+    @Test
+    fun `given current topics when initialize called then it should subscribe to all current topics`() {
+        every { mockRepository.getCurrentTopics() } returns currentTopics
+
+        useCase.initialize()
+
+        verify(exactly = 1) { mockFirebaseMessaging.subscribeToTopic("initial_en") }
+        verify(exactly = 1) { mockFirebaseMessaging.subscribeToTopic("news_en") }
+        verify(exactly = 1) { mockFirebaseMessaging.subscribeToTopic("promo_en") }
+        verify(exactly = 1) { mockFirebaseMessaging.subscribeToTopic("warn_en") }
+    }
+
+    @Test
+    fun `given current topics and new language when subscribeByLanguage called then it should unsubscribe old and subscribe new`() {
+        every { mockRepository.getCurrentTopics() } returns currentTopics
+        every { mockRepository.getTopicsByLanguage(any()) } returns newTopics
+
+        val newLanguage = Language.FRENCH
+
+        useCase.subscribeByLanguage(newLanguage)
+
+        verify(exactly = 1) { mockFirebaseMessaging.unsubscribeFromTopic("initial_en") }
+        verify(exactly = 1) { mockFirebaseMessaging.unsubscribeFromTopic("news_en") }
+        verify(exactly = 1) { mockFirebaseMessaging.unsubscribeFromTopic("promo_en") }
+        verify(exactly = 1) { mockFirebaseMessaging.unsubscribeFromTopic("warn_en") }
+
+        verify(exactly = 1) { mockFirebaseMessaging.subscribeToTopic("initial_fr") }
+        verify(exactly = 1) { mockFirebaseMessaging.subscribeToTopic("news_fr") }
+        verify(exactly = 1) { mockFirebaseMessaging.subscribeToTopic("promo_fr") }
+        verify(exactly = 1) { mockFirebaseMessaging.subscribeToTopic("warn_fr") }
+    }
+}


### PR DESCRIPTION

## 📱 Description
This commit introduces the ability to subscribe and unsubscribe from Firebase messaging topics based on the user's selected language.

## Platform
- [x] Android
- [ ] iOS
- [ ] Games-Unity
- [ ] DevOps (AWS)
- [ ] Website
- [ ] C/Golang 

## 🎯 Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or improvement

## 📋 Changes
- Added `MessagingTopicDataSource` to fetch topic configurations from a JSON file.
- Added `MessagingTopicRepository` to manage topic data.
- Added `MessagingTopicUseCase` to handle subscription logic.
- Added `LanguageSwitcherUseCase` to orchestrate language switching and topic subscription updates.
- Integrated topic subscription updates into `SettingsViewModel` and `ChangeLanguageBottomSheet`.
- Added a `topics.json` asset file containing the topic definitions.
- Included unit tests for the new data source, repository, and use cases.
- Initialized messaging topics on app startup in `BrainwalletApp`.

### 🔗 Related Issues
<!-- Link any related issues using "Fixes #issue_number" or "Closes #issue_number" -->
- close https://github.com/gruntsoftware/internal/issues/234

## 🧪 Tests Status
- [x] Tests ran successfully locally?
- [x] Added more tests? How many?
- [ ] Code coverage percentage of the codebase: __%

## 📸 Screenshots/Videos
<!-- Add screenshots or screen recordings of UI changes -->
<!-- Use the format below for before/after comparisons -->

| Before | After |
|--------|-------|
|<!-- Add screenshot/video of current behavior -->|<!-- Add screenshot/video of new behavior -->|

## 🎯 Reviewers
<!-- Tag specific reviewers or teams -->
@kcw-grunt, @josikie
