### PR TITLE
chore(#234): normalize Indonesian language code to "id"

### DIFF
--- a/app/src/main/java/com/brainwallet/data/source/MessagingTopicDataSource.kt
+++ b/app/src/main/java/com/brainwallet/data/source/MessagingTopicDataSource.kt
@@ -18,12 +18,29 @@ class MessagingTopicDataSource(
         )
     }
 
+    /**
+     * Note: Indonesian language code is normalized from "in" to "id" to maintain
+     * consistency with backend batch messaging server which uses ISO 639-1 standard.
+     * Supports both "in" and "id" as input for Indonesian language.
+     */
     private fun getBaseLanguageCode(languageCode: String): String {
         val normalizedLanguageCode = languageCode.split("_", "-").first().lowercase()
+        
+        // Handle reverse mapping: if "id" is passed, treat it as Indonesian
+        val searchCode = when (normalizedLanguageCode) {
+            "id" -> "in"
+            else -> normalizedLanguageCode
+        }
+        
         val targetLanguage = supportedLanguages.find { 
-            it.code.split("-").first().lowercase() == normalizedLanguageCode 
+            it.code.split("-").first().lowercase() == searchCode 
         } ?: defaultLanguage
         
-        return targetLanguage.code.split("-").first().lowercase()
+        val baseCode = targetLanguage.code.split("-").first().lowercase()
+        
+        return when (baseCode) {
+            "in" -> "id"
+            else -> baseCode
+        }
     }
 }

--- a/app/src/test/java/com/brainwallet/data/source/MessagingTopicDataSourceTest.kt
+++ b/app/src/test/java/com/brainwallet/data/source/MessagingTopicDataSourceTest.kt
@@ -1,6 +1,5 @@
 package com.brainwallet.data.source
 
-import com.brainwallet.data.model.Language
 import org.junit.Before
 import org.junit.Test
 
@@ -73,11 +72,44 @@ class MessagingTopicDataSourceTest {
     }
 
     @Test
+    fun `given Indonesian language code when getTopicsByLanguageCode called then it should normalize to id for backend consistency`() {
+        val result = dataSource.getTopicsByLanguageCode("in")
+
+        val expectedTopics = listOf("initial_id", "news_id", "promo_id", "warn_id")
+        assert(result == expectedTopics) {
+            "Expected Indonesian language code 'in' to be normalized to 'id' for backend consistency but got $result"
+        }
+    }
+
+    @Test
+    fun `given Indonesian locale with region when getTopicsByLanguageCode called then it should normalize to id`() {
+        val result = dataSource.getTopicsByLanguageCode("in_ID")
+
+        val expectedTopics = listOf("initial_id", "news_id", "promo_id", "warn_id")
+        assert(result == expectedTopics) {
+            "Expected Indonesian locale 'in_ID' to be normalized to 'id' for backend consistency but got $result"
+        }
+    }
+
+    @Test
+    fun `given id language code when getTopicsByLanguageCode called then it should be recognized as Indonesian`() {
+        val result = dataSource.getTopicsByLanguageCode("id")
+
+        val expectedTopics = listOf("initial_id", "news_id", "promo_id", "warn_id")
+        assert(result == expectedTopics) {
+            "Expected 'id' language code to be recognized as Indonesian and return Indonesian topics but got $result"
+        }
+    }
+
+    @Test
     fun `given all supported languages when getTopicsByLanguageCode called then it should return correct base language topics`() {
         val testCases = mapOf(
             "en" to "en",
-            "es" to "es", 
-            "in" to "in",
+            "es" to "es",
+            // Check All possible indonesian combination
+            "in" to "id",
+            "in_ID" to "id",
+            "id" to "id",
             "ar" to "ar",
             "uk" to "uk",
             "ru" to "ru",


### PR DESCRIPTION
## 📱 Description
The Indonesian language code "in" is normalized to "id" in `MessagingTopicDataSource` to align with the ISO 639-1 standard used by the backend.

This ensures consistency in topic generation for Indonesian language users. Tests have been added to verify this normalization for both "in" and "in_ID" inputs.

## Platform
- [x] Android
- [ ] iOS
- [ ] Games-Unity
- [ ] DevOps (AWS)
- [ ] Website
- [ ] C/Golang 

## 🎯 Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement

## 📋 Changes
- Add Normalization for `id`

### 🔗 Related Issues
- Related to https://github.com/gruntsoftware/internal/issues/234
- Related to PR https://github.com/gruntsoftware/android/pull/132

## 🧪 Tests Status
- [x] Tests ran successfully locally?
- [x] Added more tests? How many? Added 1 test to verify always subscribed to `id` not `in`
- [ ] Code coverage percentage of the codebase: __%

## 📸 Screenshots/Videos
N/A Behavior is not changing on front side

## 🎯 Reviewers
<!-- Tag specific reviewers or teams -->
@kcw-grunt, @josikie
