### PR TITLE
bug(crashlytics): Remove InputWordsActivity from AndroidManifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -174,11 +174,7 @@
             android:exported="true"
             android:launchMode="singleTask"
             android:screenOrientation="portrait" />
-        <activity
-            android:name=".presenter.activities.InputWordsActivity"
-            android:exported="true"
-            android:launchMode="singleTask"
-            android:screenOrientation="portrait" />
+
         <activity
             android:name=".presenter.activities.camera.ScanQRActivity"
             android:exported="true"


### PR DESCRIPTION
## 📱 Description
Fix crashes caused by removed activity that still defined on manifest

## Platform
- [x] Android
- [ ] iOS
- [ ] Games-Unity
- [ ] DevOps (AWS)
- [ ] Website
- [ ] C/Golang 

## 🎯 Type of Change
<!-- Mark the relevant option with an [x] -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement

## 📋 Changes
Removed unused activity

### 🔗 Related Issues
<!-- Link any related issues using "Fixes #issue_number" or "Closes #issue_number" -->
- Fixes https://github.com/gruntsoftware/internal/issues/273
- Related to https://console.firebase.google.com/u/0/project/brainwallet-mobile/crashlytics/app/android:ltd.grunt.brainwallet/issues/ca8f7f21e3ec633d0d1dca453409435b?time=90d&types=crash&sessionEventKey=68EB8524039900014A7CFC151688CB00_2138728396689588373

## 🧪 Tests Status
- [ ] Tests ran successfully locally?
- [ ] Added more tests? How many?
- [ ] Code coverage percentage of the codebase: __%

## 📸 Screenshots/Videos
<!-- Add screenshots or screen recordings of UI changes -->
<!-- Use the format below for before/after comparisons -->

| Before | After |
|--------|-------|
|<!-- Add screenshot/video of current behavior -->|<!-- Add screenshot/video of new behavior -->|

## 🎯 Reviewers
<!-- Tag specific reviewers or teams -->
@kcw-grunt, @josikie
