### PR TITLE
5th. Feat(Bento, #280): Use legacy settings rail menu and localization

### DIFF
--- a/app/src/main/java/com/brainwallet/domain/flow/BalanceStateFlowImpl.kt
+++ b/app/src/main/java/com/brainwallet/domain/flow/BalanceStateFlowImpl.kt
@@ -28,10 +28,14 @@ class BalanceStateFlowImpl(
             )
         }
     )
-) : BalanceStateFlow, StateFlow<BalanceState> by upstream, BRWalletManager.OnBalanceChanged {
+) : BalanceStateFlow,
+    StateFlow<BalanceState> by upstream,
+    BRWalletManager.OnBalanceChanged,
+    BRSharedPrefs.OnIsoChangedListener {
 
     init {
         BRWalletManager.getInstance().addBalanceChangedListener(this)
+        BRSharedPrefs.addIsoChangedListener(this)
         refreshBalance()
     }
 
@@ -48,6 +52,10 @@ class BalanceStateFlowImpl(
                 )
             }
         }
+    }
+
+    override fun onIsoChanged(iso: String?) {
+        refreshBalance()
     }
 }
 

--- a/app/src/main/java/com/brainwallet/domain/flow/PriceTickerStateFlowImpl.kt
+++ b/app/src/main/java/com/brainwallet/domain/flow/PriceTickerStateFlowImpl.kt
@@ -1,48 +1,73 @@
 package com.brainwallet.domain.flow
 
 import android.content.Context
+import com.brainwallet.data.model.CurrencyEntity
+import com.brainwallet.data.repository.LtcRepository
 import com.brainwallet.ltc.domain.flow.PriceTickerStateFlow
 import com.brainwallet.ltc.domain.model.TradingPairData
-import com.brainwallet.tools.sqlite.CurrencyDataSource
 import com.brainwallet.tools.util.BRCurrency
 import com.brainwallet.tools.util.BRExchange
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import org.koin.core.annotation.Single
 import java.math.BigDecimal
+import kotlin.collections.map
 
 @OptIn(ExperimentalForInheritanceCoroutinesApi::class)
 @Single
 class PriceTickerStateFlowImpl(
     private val context: Context,
+    private val ltcRepository: LtcRepository,
+    // Using a default value here to avoid blocking the constructor, will refresh immediately in init
     private val upstream: MutableStateFlow<PersistentList<TradingPairData>> = MutableStateFlow(
-        getTradingPairsFromExchangeRates(context)
+        defaultTradingPairs
     )
 ) : PriceTickerStateFlow, StateFlow<PersistentList<TradingPairData>> by upstream {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    init {
+        refreshPrices()
+    }
 
     override fun refreshPrices() {
-        upstream.value = getTradingPairsFromExchangeRates(context)
+        scope.launch {
+            // 1. Fetch fresh rates from the repository (this also updates the local DB internally)
+            val rates = ltcRepository.fetchRates()
+
+            // 2. Map the results using legacy helpers to ensure consistency with existing math
+            val tradingPairs = mapRatesToTradingPairs(rates)
+
+            // 3. Update the state flow
+            if (tradingPairs.isNotEmpty()) {
+                upstream.value = tradingPairs
+            }
+        }
     }
-}
 
-private fun getTradingPairsFromExchangeRates(context: Context): PersistentList<TradingPairData> {
-    val currencyDataSource = CurrencyDataSource.getInstance(context)
-    val oneLitecoinInLitoshis = BigDecimal(BRExchange.ONE_LITECOIN_OF_LITOSHIS)
+    private fun mapRatesToTradingPairs(rates: List<CurrencyEntity>): PersistentList<TradingPairData> {
+        val oneLitecoinInLitoshis = BigDecimal(BRExchange.ONE_LITECOIN_OF_LITOSHIS)
 
-    val supportedCurrencies = listOf("USD", "EUR", "GBP", "JPY")
+        // We use the rates returned from the repo to drive the list,
+        // ensuring we show ALL supported currencies, not just a filtered list.
+        val tradingPairs = rates.map { currencyEntity ->
+            val isoCode = currencyEntity.code
 
-    val tradingPairs = supportedCurrencies.mapNotNull { isoCode ->
-        val currencyEntity = currencyDataSource.getCurrencyByIso(isoCode)
-        currencyEntity?.let {
+            // logic preserved from original code using BRExchange/BRCurrency
+            // to ensure price calculations remain identical.
             val priceInCurrency = BRExchange.getAmountFromLitoshis(
                 context,
                 isoCode,
                 oneLitecoinInLitoshis
             )
+
             val formattedPrice = BRCurrency.getFormattedCurrencyString(
                 context,
                 isoCode,
@@ -55,24 +80,21 @@ private fun getTradingPairsFromExchangeRates(context: Context): PersistentList<T
                 formattedPrice = formattedPrice
             )
         }
+
+        return tradingPairs.toPersistentList()
     }
 
-    return if (tradingPairs.isNotEmpty()) {
-        tradingPairs.toPersistentList()
-    } else {
-        defaultTradingPairs
-    }
-}
-
-private fun formatPrice(price: Double): String {
-    return when {
-        price >= 1000 -> String.format("%.2f", price).replace(",", " ")
-        price >= 100 -> String.format("%.2f", price)
-        price >= 10 -> String.format("%.3f", price)
-        else -> String.format("%.4f", price)
+    private fun formatPrice(price: Double): String {
+        return when {
+            price >= 1000 -> String.format("%.2f", price).replace(",", " ")
+            price >= 100 -> String.format("%.2f", price)
+            price >= 10 -> String.format("%.3f", price)
+            else -> String.format("%.4f", price)
+        }
     }
 }
 
+// Kept as fallback for the initial StateFlow value
 private val defaultTradingPairs = persistentListOf(
     TradingPairData("LTC/USD", 115.96, "$115.96"),
     TradingPairData("LTC/EUR", 108.45, "€108.45"),

--- a/app/src/main/java/com/brainwallet/presenter/activities/BreadActivity.java
+++ b/app/src/main/java/com/brainwallet/presenter/activities/BreadActivity.java
@@ -84,33 +84,33 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
     public static final Point screenParametersPoint = new Point();
     private static final float PRIMARY_TEXT_SIZE = 24f;
     private static final float SECONDARY_TEXT_SIZE = 12.8f;
-    private int mSelectedBottomNavItem = -1;
+    protected int mSelectedBottomNavItem = -1;
 
-    private InternetManager mConnectionReceiver;
-    private Button primaryPrice;
-    private Button secondaryPrice;
-    private TextView equals;
-    private ImageButton menuBut;
-    private TextView balanceTxtV;
+    protected InternetManager mConnectionReceiver;
+    protected Button primaryPrice;
+    protected Button secondaryPrice;
+    protected TextView equals;
+    protected ImageButton menuBut;
+    protected TextView balanceTxtV;
 
     public static boolean appVisible = false;
     public ViewFlipper barFlipper;
-    private ConstraintLayout toolBarConstraintLayout;
-    private boolean uiIsDone;
+    protected ConstraintLayout toolBarConstraintLayout;
+    protected boolean uiIsDone;
 
     private static BreadActivity app;
-    private BottomNavigationView bottomNav;
+    protected BottomNavigationView bottomNav;
 
-    private Handler mHandler = new Handler();
-    private NavigationView navigationDrawer;
-    private DrawerLayout drawerLayout;
-    private HomeSettingDrawerComposeView homeSettingDrawerComposeView;
+    protected Handler mHandler = new Handler();
+    protected NavigationView navigationDrawer;
+    protected DrawerLayout drawerLayout;
+    protected HomeSettingDrawerComposeView homeSettingDrawerComposeView;
 
     public static BreadActivity getApp() {
         return app;
     }
 
-    private final ActivityResultLauncher<String> requestNotificationPermissionLauncher =
+    protected final ActivityResultLauncher<String> requestNotificationPermissionLauncher =
             registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
                 if (isGranted) {
                     Toast.makeText(app, R.string.permission_notification_granted, Toast.LENGTH_SHORT).show();
@@ -120,7 +120,15 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setupContentView();
+        onCreateAfterSetContent(savedInstanceState);
+    }
+
+    protected void setupContentView() {
         setContentView(R.layout.activity_bread);
+    }
+
+    protected void onCreateAfterSetContent(Bundle savedInstanceState) {
         AnalyticsManager.logCustomEvent(BRConstants._HOME_OPEN);
 
         app = this;
@@ -132,21 +140,28 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         setUpBarFlipper();
         checkTransactionDatabase();
 
-        primaryPrice.setTextSize(PRIMARY_TEXT_SIZE);
-        secondaryPrice.setTextSize(SECONDARY_TEXT_SIZE);
+        if (primaryPrice != null) {
+            primaryPrice.setTextSize(PRIMARY_TEXT_SIZE);
+        }
+        if (secondaryPrice != null) {
+            secondaryPrice.setTextSize(SECONDARY_TEXT_SIZE);
+        }
 
         finishActivities(SetPinActivity.introSetPitActivity, ReEnterPinActivity.reEnterPinActivity);
 
         onConnectionChanged(InternetManager.getInstance().isConnected(this));
 
         updateUI();
-        bottomNav.setSelectedItemId(R.id.nav_history);
+        
+        if (bottomNav != null) {
+            bottomNav.setSelectedItemId(R.id.nav_history);
+        }
 
         setupNotificationPermission();
         showInAppReviewDialogIfNeeded();
     }
 
-    private void setupNotificationPermission() {
+    protected void setupNotificationPermission() {
         //https://developer.android.com/develop/ui/views/notifications/notification-permission
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
             return;
@@ -170,13 +185,13 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         }
     }
 
-    private void finishActivities(BRActivity... activities) {
+    protected void finishActivities(BRActivity... activities) {
         for (BRActivity activity : activities) {
             if (activity != null) activity.finish();
         }
     }
 
-    private void showInAppReviewDialogIfNeeded() {
+    protected void showInAppReviewDialogIfNeeded() {
         if (!BRSharedPrefs.isInAppReviewDone(this) && BRSharedPrefs.getSendTransactionCount(this) > 2) {
             ReviewManager manager = ReviewManagerFactory.create(this);
             Task<ReviewInfo> request = manager.requestReviewFlow();
@@ -202,17 +217,17 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         }
     }
 
-    private void addObservers() {
+    protected void addObservers() {
         BRWalletManager.getInstance().addBalanceChangedListener(this);
         BRSharedPrefs.addIsoChangedListener(this);
     }
 
-    private void removeObservers() {
+    protected void removeObservers() {
         BRWalletManager.getInstance().removeListener(this);
         BRSharedPrefs.removeListener(this);
     }
 
-    private void setUrlHandler(Intent intent) {
+    protected void setUrlHandler(Intent intent) {
         Uri data = intent.getData();
         if (data == null) return;
         String scheme = data.getScheme();
@@ -228,7 +243,9 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         setUrlHandler(intent);
     }
 
-    private void setListeners() {
+    protected void setListeners() {
+        if (bottomNav == null) return;
+        
         bottomNav.setOnNavigationItemSelectedListener(item -> handleNavigationItemSelected(item.getItemId()));
 
         primaryPrice.setOnClickListener(v -> swap());
@@ -240,7 +257,7 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         });
     }
 
-    public boolean handleNavigationItemSelected(int menuItemId) {
+    protected boolean handleNavigationItemSelected(int menuItemId) {
         if (mSelectedBottomNavItem == menuItemId) return true;
         mSelectedBottomNavItem = menuItemId;
 
@@ -274,7 +291,7 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         return true;
     }
 
-    private void swap() {
+    protected void swap() {
         if (!BRAnimator.isClickAllowed()) return;
         boolean b = !BRSharedPrefs.getPreferredLTC(this);
         setPriceTags(b, true);
@@ -282,7 +299,9 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         BRSharedPrefs.notifyIsoChanged("");
     }
 
-    private void setPriceTags(boolean ltcPreferred, boolean animate) {
+    protected void setPriceTags(boolean ltcPreferred, boolean animate) {
+        if (toolBarConstraintLayout == null) return;
+        
         ConstraintSet set = new ConstraintSet();
         set.clone(toolBarConstraintLayout);
 
@@ -338,11 +357,13 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         mHandler.postDelayed(() -> updateUI(), toolBarConstraintLayout.getLayoutTransition().getDuration(LayoutTransition.CHANGING));
     }
 
-    private void checkTransactionDatabase() {
+    protected void checkTransactionDatabase() {
 
     }
 
-    private void setUpBarFlipper() {
+    protected void setUpBarFlipper() {
+        if (barFlipper == null) return;
+        
         barFlipper.setInAnimation(AnimationUtils.loadAnimation(this, R.anim.flipper_enter));
         barFlipper.setOutAnimation(AnimationUtils.loadAnimation(this, R.anim.flipper_exit));
     }
@@ -370,7 +391,7 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         BRWalletManager.getInstance().refreshBalance(this);
     }
 
-    private void setupNetworking() {
+    protected void setupNetworking() {
         if (mConnectionReceiver == null) mConnectionReceiver = InternetManager.getInstance();
         IntentFilter mNetworkStateFilter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
         registerReceiver(mConnectionReceiver, mNetworkStateFilter);
@@ -390,8 +411,9 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
         unregisterReceiver(mConnectionReceiver);
     }
 
-    private void initializeViews() {
+    protected void initializeViews() {
         menuBut = findViewById(R.id.menuBut);
+        if (menuBut == null) return;
 
         navigationDrawer = findViewById(R.id.navigationDrawer);
         drawerLayout = findViewById(R.id.drawerLayout);
@@ -453,6 +475,8 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
     }
 
     public void updateUI() {
+        if (primaryPrice == null || secondaryPrice == null) return;
+        
         BRExecutor.getInstance().forLightWeightBackgroundTasks().execute(() -> {
             Thread.currentThread().setName(Thread.currentThread().getName() + ":updateUI");
             //sleep a little in order to make sure all the commits are finished (like SharePreferences commits)
@@ -468,8 +492,10 @@ public class BreadActivity extends BRActivity implements BRWalletManager.OnBalan
             final BigDecimal curAmount = BRExchange.getAmountFromLitoshis(BreadActivity.this, iso, amount);
             final String formattedCurAmount = BRCurrency.getFormattedCurrencyString(BreadActivity.this, iso, curAmount);
             runOnUiThread(() -> {
-                primaryPrice.setText(formattedBTCAmount);
-                secondaryPrice.setText(String.format("%s", formattedCurAmount));
+                if (primaryPrice != null && secondaryPrice != null) {
+                    primaryPrice.setText(formattedBTCAmount);
+                    secondaryPrice.setText(String.format("%s", formattedCurAmount));
+                }
             });
         });
     }

--- a/app/src/main/java/com/brainwallet/ui/bento/BentoActivity.kt
+++ b/app/src/main/java/com/brainwallet/ui/bento/BentoActivity.kt
@@ -2,23 +2,35 @@ package com.brainwallet.ui.bento
 
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.ui.graphics.toArgb
-import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
+import com.brainwallet.R
 import com.brainwallet.design.presentation.state.rememberDarkModeState
+import com.brainwallet.navigation.LegacyNavigation.restartBreadActivity
+import com.brainwallet.navigation.LegacyNavigation.startBreadActivity
 import com.brainwallet.navigation.MainNavHost
 import com.brainwallet.navigation.Route
-import com.brainwallet.tools.threads.BRExecutor
-import com.brainwallet.wallet.BRWalletManager
+import com.brainwallet.navigation.Route.UnLock
+import com.brainwallet.presenter.activities.BreadActivity
+import com.brainwallet.presenter.activities.settings.SyncBlockchainActivity
+import com.brainwallet.tools.manager.BRSharedPrefs
+import com.brainwallet.tools.security.PostAuth
+import com.brainwallet.ui.BrainwalletActivity.Companion.createIntent
+import com.brainwallet.ui.screens.home.SettingsViewModel
+import com.brainwallet.util.EventBus
 import com.grunt.brainwallet.core.presentation.theme.BrainwalletTheme
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 
-class BentoActivity : FragmentActivity() {
+class BentoActivity : BreadActivity() {
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+    override fun setupContentView() {
+        observeLegacyMenuEvent()
         setContent {
             val darkModeState = rememberDarkModeState()
             BrainwalletTheme(darkModeState.isDarkMode) {
@@ -38,11 +50,39 @@ class BentoActivity : FragmentActivity() {
         }
     }
 
-    override fun onResume() {
-        super.onResume()
-        if (!BRWalletManager.getInstance().isCreated()) {
-            BRExecutor.getInstance().forBackgroundTasks()
-                .execute(Runnable { BRWalletManager.getInstance().initWallet(this) })
+    private fun observeLegacyMenuEvent() {
+        EventBus.events
+            .filter { it is EventBus.Event.Message }
+            .map { it as EventBus.Event.Message }
+            .onEach { handleLegacyMessage(it.message) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun handleLegacyMessage(message: String) {
+        when (message) {
+            SettingsViewModel.LEGACY_EFFECT_ON_LOCK -> {
+                startBreadActivity(this, true)
+            }
+            SettingsViewModel.LEGACY_EFFECT_ON_TOGGLE_DARK_MODE -> {
+                restartBreadActivity(this)
+            }
+            SettingsViewModel.LEGACY_EFFECT_ON_SEC_UPDATE_PIN -> {
+                createIntent(this, UnLock(true)).apply {
+                    putExtra("noPin", true)
+                    startActivity(this)
+                }
+            }
+            SettingsViewModel.LEGACY_EFFECT_ON_SEED_PHRASE -> {
+                PostAuth.getInstance().onPhraseCheckAuth(this, true)
+            }
+            SettingsViewModel.LEGACY_EFFECT_ON_SHARE_ANALYTICS_DATA_TOGGLE -> {
+                val isEnabled = BRSharedPrefs.getShareData(this)
+                BRSharedPrefs.putShareData(this, !isEnabled)
+            }
+            SettingsViewModel.LEGACY_EFFECT_ON_SYNC -> {
+                startActivity(Intent(this, SyncBlockchainActivity::class.java))
+                overridePendingTransition(R.anim.enter_from_right, R.anim.exit_to_left)
+            }
         }
     }
 

--- a/app/src/main/java/com/brainwallet/ui/bento/BentoMainScreen.kt
+++ b/app/src/main/java/com/brainwallet/ui/bento/BentoMainScreen.kt
@@ -1,8 +1,8 @@
 package com.brainwallet.ui.bento
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -26,7 +26,9 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -37,27 +39,25 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.fragment.compose.AndroidFragment
 import androidx.fragment.compose.rememberFragmentState
 import com.brainwallet.design.presentation.component.effect.AnimatedLightBleedBackground
 import com.brainwallet.design.presentation.component.effect.DrawerOpacityContainer
 import com.brainwallet.design.presentation.component.effect.LightOpacityContainer
-import com.brainwallet.design.presentation.component.rail.BentoRail
 import com.brainwallet.design.presentation.component.widget.BentoBottomNavBar
-import com.brainwallet.ltc.presentation.component.balance.BalanceBentoGrid
-import com.brainwallet.ltc.presentation.component.FavoriteGrid
-import com.brainwallet.ltc.presentation.component.ticker.PriceTickerGrid
-import com.brainwallet.ltc.presentation.component.transactionhistory.TransactionHistoryGrid
-import com.brainwallet.design.presentation.component.widget.BentoRailButton
 import com.brainwallet.design.presentation.component.widget.BentoDarkModeToggle
+import com.brainwallet.design.presentation.component.widget.BentoRailButton
 import com.brainwallet.design.presentation.state.DarkModeState
 import com.brainwallet.design.presentation.state.rememberDarkModeState
 import com.brainwallet.gamehub.presentation.component.GameHubGrid
+import com.brainwallet.ltc.presentation.component.FavoriteGrid
+import com.brainwallet.ltc.presentation.component.balance.BalanceBentoGrid
+import com.brainwallet.ltc.presentation.component.ticker.PriceTickerGrid
+import com.brainwallet.ltc.presentation.component.transactionhistory.TransactionHistoryGrid
 import com.brainwallet.navigation.OnNavigate
 import com.brainwallet.presenter.fragments.FragmentSend
 import com.brainwallet.tutorial.presentation.component.TutorialGrid
+import com.brainwallet.ui.screens.home.composable.HomeSettingDrawerSheet
 import com.brainwallet.ui.screens.home.receive.ReceiveDialog
 import com.grunt.brainwallet.core.presentation.theme.BrainwalletTheme
 
@@ -211,13 +211,7 @@ private fun BentoMainScreen(
             DrawerOpacityContainer(
                 modifier = Modifier.fillMaxSize()
             ) {
-                BentoRail(
-                    userName = "Joseph Sanjaya",
-                    appVersion = "v.X.X.X (XXXXXXXXXXXX)",
-                    modifier = Modifier
-                        .statusBarsPadding()
-                        .navigationBarsPadding()
-                )
+                HomeSettingDrawerSheet(darkModeState = darkModeState)
             }
         }
 

--- a/app/src/main/java/com/brainwallet/ui/screens/home/SettingsEvent.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/home/SettingsEvent.kt
@@ -13,7 +13,6 @@ sealed class SettingsEvent {
     object OnSecurityUpdatePinClick : SettingsEvent()
     object OnSecuritySeedPhraseClick : SettingsEvent()
     object OnSecurityShareAnalyticsDataClick : SettingsEvent()
-    object OnToggleDarkMode : SettingsEvent()
     object OnToggleLock : SettingsEvent()
     object OnLanguageSelectorButtonClick : SettingsEvent()
     object OnLanguageSelectorDismiss : SettingsEvent()

--- a/app/src/main/java/com/brainwallet/ui/screens/home/SettingsState.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/home/SettingsState.kt
@@ -10,7 +10,6 @@ import com.brainwallet.tools.manager.FeeManager
 import com.brainwallet.data.repository.SyncAnalyticsRepository
 
 data class SettingsState(
-    val darkMode: Boolean = true,
     val selectedLanguage: Language = Language.ENGLISH,
     val selectedCurrency: CurrencyEntity = CurrencyEntity(
         "USD",

--- a/app/src/main/java/com/brainwallet/ui/screens/home/SettingsViewModel.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/home/SettingsViewModel.kt
@@ -32,7 +32,9 @@ class SettingsViewModel(
     private val ltcRepository: LtcRepository
 ) : BrainwalletViewModel<SettingsEvent>() {
 
-    private val _state = MutableStateFlow(SettingsState())
+    private val _state = MutableStateFlow(
+        SettingsState()
+    )
     val state: StateFlow<SettingsState> = _state.asStateFlow()
 
     val appSetting = settingRepository.settings
@@ -40,7 +42,6 @@ class SettingsViewModel(
         .onEach { setting ->
             _state.update {
                 it.copy(
-                    darkMode = setting.isDarkMode,
                     selectedLanguage = Language.find(setting.languageCode),
                     selectedCurrency = setting.currency,
                 )
@@ -81,21 +82,6 @@ class SettingsViewModel(
                         selectedFeeType = settingRepository.getSelectedFeeType()
                     )
                 }
-            }
-
-            SettingsEvent.OnToggleDarkMode -> viewModelScope.launch {
-                _state.update {
-                    val toggled = it.darkMode.not()
-
-                    settingRepository.save(
-                        appSetting.value.copy(
-                            isDarkMode = toggled
-                        )
-                    )
-
-                    it.copy(darkMode = toggled)
-                }
-                EventBus.emit(EventBus.Event.Message(LEGACY_EFFECT_ON_TOGGLE_DARK_MODE))
             }
 
             SettingsEvent.OnToggleLock -> viewModelScope.launch {

--- a/app/src/main/java/com/brainwallet/ui/screens/home/composable/HomeSettingDrawerSheet.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/home/composable/HomeSettingDrawerSheet.kt
@@ -5,14 +5,10 @@ import android.net.Uri
 import android.util.AttributeSet
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -29,6 +25,8 @@ import androidx.lifecycle.findViewTreeLifecycleOwner
 import com.brainwallet.R
 import com.brainwallet.data.model.AppSetting
 import com.brainwallet.data.repository.SyncAnalyticsRepository
+import com.brainwallet.design.presentation.state.DarkModeState
+import com.brainwallet.design.presentation.state.rememberDarkModeState
 import com.brainwallet.tools.manager.BRSharedPrefs
 import com.brainwallet.tools.util.BRConstants
 import com.brainwallet.ui.screens.home.SettingsEvent
@@ -42,7 +40,6 @@ import com.brainwallet.ui.screens.home.composable.settingsrows.SecurityDetail
 import com.brainwallet.ui.screens.home.composable.settingsrows.SettingRowItem
 import com.brainwallet.ui.screens.home.composable.settingsrows.ThemeSettingRowItem
 import com.brainwallet.ui.theme.BrainwalletAppTheme
-import com.grunt.brainwallet.core.presentation.theme.BrainwalletTheme
 import com.brainwallet.util.EventBus
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
@@ -55,6 +52,7 @@ import org.koin.java.KoinJavaComponent.inject
 @Composable
 fun HomeSettingDrawerSheet(
     modifier: Modifier = Modifier,
+    darkModeState: DarkModeState = rememberDarkModeState(),
     syncAnalyticsRepository: SyncAnalyticsRepository = koinInject(),
     viewModel: SettingsViewModel = koinViewModel()
 ) {
@@ -75,147 +73,138 @@ fun HomeSettingDrawerSheet(
     // / Layout values
     val headerPadding = 56
 
-    ModalDrawerSheet(
+    LazyColumn(
         modifier = modifier
-            .fillMaxWidth()
-            .verticalScroll(rememberScrollState()),
-        drawerContainerColor = BrainwalletTheme.colors.surface,
-        drawerContentColor = BrainwalletTheme.colors.content
+            .testTag("lazyColumnSetting")
+            .padding(top = headerPadding.dp)
+            .wrapContentHeight(align = Alignment.Top)
     ) {
-        LazyColumn(
-            modifier = Modifier
-                .testTag("lazyColumnSetting")
-                .weight(1f)
-                .padding(top = headerPadding.dp)
-                .wrapContentHeight(align = Alignment.Top)
-        ) {
-            item {
-                SecurityDetail(
-                    modifier = Modifier
-                        .testTag("settingSecurity")
-                        .fillMaxSize()
-                        .wrapContentHeight(),
-                    shareAnalyticsDataEnabled = state.shareAnalyticsDataEnabled,
-                    onEvent = {
-                        viewModel.onEvent(it)
-                    }
-                )
-            }
-            item {
-                LanguageDetail(
-                    modifier = Modifier
-                        .testTag("settingLanguage")
-                        .fillMaxSize()
-                        .wrapContentHeight(),
-                    selectedLanguage = state.selectedLanguage,
-                    onLanguageSelect = { language ->
-                        viewModel.onEvent(
-                            SettingsEvent.OnLanguageChange(
-                                language
-                            )
-                        )
-                    }
-                )
-            }
-            item {
-                CurrencyDetail(
-                    modifier = Modifier
-                        .testTag("settingCurrency")
-                        .fillMaxSize()
-                        .wrapContentHeight(),
-                    selectedCurrency = state.selectedCurrency,
-                    onFiatSelect = { currency ->
-                        viewModel.onEvent(
-                            SettingsEvent.OnFiatChange(
-                                currency
-                            )
-                        )
-                    }
-                )
-            }
-            item {
-                GamesDetail(
-                    modifier = Modifier
-                        .testTag("settingGames")
-                        .fillMaxSize()
-                        .wrapContentHeight()
-                )
-            }
-            item {
-                LitecoinBlockchainDetail(
-                    modifier = Modifier
-                        .testTag("settingBlockchain")
-                        .fillMaxSize()
-                        .wrapContentHeight(),
-                    selectedCurrency = state.selectedCurrency,
-                    selectedFeeType = state.selectedFeeType,
-                    feeOptions = state.currentFeeOptions,
-                    onEvent = {
-                        viewModel.onEvent(it)
-                    }
-                )
-            }
-            item {
-                SettingRowItem(
-                    modifier = Modifier.testTag("settingSupport"),
-                    title = stringResource(R.string.settings_title_support),
-                    description = "brainwallet.co/support.html",
-                    onClick = {
-                        val builder = CustomTabsIntent.Builder()
-                        val customTabsIntent = builder.build()
-                        customTabsIntent.launchUrl(context, Uri.parse(BRConstants.SUPPORT_WEB_LINK))
-                    }
-                )
-            }
-            item {
-                SettingRowItem(
-                    modifier = Modifier.testTag("settingSocialMedia"),
-                    title = stringResource(R.string.settings_title_social_media),
-                    description = "linktr.ee/brainwallet",
-                    onClick = {
-                        val builder = CustomTabsIntent.Builder()
-                        val customTabsIntent = builder.build()
-                        customTabsIntent.launchUrl(context, Uri.parse(BRConstants.LINKTREE_URL))
-                    }
-                )
-            }
-            item {
-                // Lock / Unlock
-                LockSettingRowItem(
-                    modifier = Modifier.testTag("settingLock"),
-                ) {
-                    viewModel.onEvent(SettingsEvent.OnToggleLock)
+        item {
+            SecurityDetail(
+                modifier = Modifier
+                    .testTag("settingSecurity")
+                    .fillMaxSize()
+                    .wrapContentHeight(),
+                shareAnalyticsDataEnabled = state.shareAnalyticsDataEnabled,
+                onEvent = {
+                    viewModel.onEvent(it)
                 }
+            )
+        }
+        item {
+            LanguageDetail(
+                modifier = Modifier
+                    .testTag("settingLanguage")
+                    .fillMaxSize()
+                    .wrapContentHeight(),
+                selectedLanguage = state.selectedLanguage,
+                onLanguageSelect = { language ->
+                    viewModel.onEvent(
+                        SettingsEvent.OnLanguageChange(
+                            language
+                        )
+                    )
+                }
+            )
+        }
+        item {
+            CurrencyDetail(
+                modifier = Modifier
+                    .testTag("settingCurrency")
+                    .fillMaxSize()
+                    .wrapContentHeight(),
+                selectedCurrency = state.selectedCurrency,
+                onFiatSelect = { currency ->
+                    viewModel.onEvent(
+                        SettingsEvent.OnFiatChange(
+                            currency
+                        )
+                    )
+                }
+            )
+        }
+        item {
+            GamesDetail(
+                modifier = Modifier
+                    .testTag("settingGames")
+                    .fillMaxSize()
+                    .wrapContentHeight()
+            )
+        }
+        item {
+            LitecoinBlockchainDetail(
+                modifier = Modifier
+                    .testTag("settingBlockchain")
+                    .fillMaxSize()
+                    .wrapContentHeight(),
+                selectedCurrency = state.selectedCurrency,
+                selectedFeeType = state.selectedFeeType,
+                feeOptions = state.currentFeeOptions,
+                onEvent = {
+                    viewModel.onEvent(it)
+                }
+            )
+        }
+        item {
+            SettingRowItem(
+                modifier = Modifier.testTag("settingSupport"),
+                title = stringResource(R.string.settings_title_support),
+                description = "brainwallet.co/support.html",
+                onClick = {
+                    val builder = CustomTabsIntent.Builder()
+                    val customTabsIntent = builder.build()
+                    customTabsIntent.launchUrl(context, Uri.parse(BRConstants.SUPPORT_WEB_LINK))
+                }
+            )
+        }
+        item {
+            SettingRowItem(
+                modifier = Modifier.testTag("settingSocialMedia"),
+                title = stringResource(R.string.settings_title_social_media),
+                description = "linktr.ee/brainwallet",
+                onClick = {
+                    val builder = CustomTabsIntent.Builder()
+                    val customTabsIntent = builder.build()
+                    customTabsIntent.launchUrl(context, Uri.parse(BRConstants.LINKTREE_URL))
+                }
+            )
+        }
+        item {
+            // Lock / Unlock
+            LockSettingRowItem(
+                modifier = Modifier.testTag("settingLock"),
+            ) {
+                viewModel.onEvent(SettingsEvent.OnToggleLock)
             }
-            item {
-                // Theme
-                ThemeSettingRowItem(
-                    darkMode = state.darkMode,
-                    onToggledDarkMode = {
-                        viewModel.onEvent(SettingsEvent.OnToggleDarkMode)
-                    }
-                )
-            }
+        }
+        item {
+            // Theme
+            ThemeSettingRowItem(
+                darkMode = darkModeState.isDarkMode,
+                onToggledDarkMode = {
+                    darkModeState.toggle()
+                }
+            )
+        }
 
-            item {
-                val description = state.lastSyncMetadata?.let {
-                    SyncAnalyticsRepository.SyncMetadata.Formatter()
-                        .format(it)
-                } ?: "No sync metadata"
+        item {
+            val description = state.lastSyncMetadata?.let {
+                SyncAnalyticsRepository.SyncMetadata.Formatter()
+                    .format(it)
+            } ?: "No sync metadata"
 
-                SettingRowItem(
-                    modifier = Modifier.height(100.dp),
-                    title = stringResource(R.string.settings_title_sync_metadata),
-                    description = description
-                )
-            }
+            SettingRowItem(
+                modifier = Modifier.height(100.dp),
+                title = stringResource(R.string.settings_title_sync_metadata),
+                description = description
+            )
+        }
 
-            item {
-                SettingRowItem(
-                    title = stringResource(R.string.settings_title_app_version),
-                    description = BRConstants.APP_VERSION_NAME_CODE
-                )
-            }
+        item {
+            SettingRowItem(
+                title = stringResource(R.string.settings_title_app_version),
+                description = BRConstants.APP_VERSION_NAME_CODE
+            )
         }
     }
 }

--- a/modules/design-system/build.gradle.kts
+++ b/modules/design-system/build.gradle.kts
@@ -21,6 +21,11 @@ android {
         minSdk = 29
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        
+        resourceConfigurations += listOf(
+            "en", "ar", "de", "es", "fa", "fr", "hi", "in", "it", "ja",
+            "ko", "pa", "pl", "pt", "ru", "sv", "tr", "uk", "zh-rCN", "zh-rTW"
+        )
     }
 
     buildTypes {

--- a/modules/design-system/src/main/java/com/brainwallet/design/presentation/component/rail/BentoRailLearningBanner.kt
+++ b/modules/design-system/src/main/java/com/brainwallet/design/presentation/component/rail/BentoRailLearningBanner.kt
@@ -10,10 +10,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import com.brainwallet.design.R
 import com.brainwallet.design.presentation.component.effect.MediumOpacityContainer
 import com.grunt.brainwallet.core.presentation.theme.BrainwalletTheme
 
@@ -38,7 +40,7 @@ fun BentoRailLearningBanner(
             contentAlignment = Alignment.Center
         ) {
             Text(
-                "Learning Banner",
+                stringResource(R.string.design_rail_learning_banner_text),
                 style = BrainwalletTheme.typography.bodyLarge.copy(
                     color = BrainwalletTheme.colors.content,
                     textAlign = TextAlign.Center,

--- a/modules/design-system/src/main/java/com/brainwallet/design/presentation/component/widget/BentoBottomNavBar.kt
+++ b/modules/design-system/src/main/java/com/brainwallet/design/presentation/component/widget/BentoBottomNavBar.kt
@@ -7,10 +7,10 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.brainwallet.design.R
 import com.grunt.brainwallet.core.presentation.theme.BrainwalletTheme
@@ -31,14 +31,12 @@ fun BentoBottomNavBar(
     onItemClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val items = remember {
-        listOf(
-            BentoBottomNavItem("Send", R.drawable.ic_sent, "send"),
-            BentoBottomNavItem("Buy/Receive", R.drawable.ic_buy, "buy_receive"),
-            BentoBottomNavItem("Game Hub", R.drawable.ic_game_hub, "game_hub"),
-            BentoBottomNavItem("History", R.drawable.ic_history, "history")
-        )
-    }
+    val items = listOf(
+        BentoBottomNavItem(stringResource(R.string.design_bottom_nav_send), R.drawable.ic_sent, "send"),
+        BentoBottomNavItem(stringResource(R.string.design_bottom_nav_buy_receive), R.drawable.ic_buy, "buy_receive"),
+        BentoBottomNavItem(stringResource(R.string.design_bottom_nav_game_hub), R.drawable.ic_game_hub, "game_hub"),
+        BentoBottomNavItem(stringResource(R.string.design_bottom_nav_history), R.drawable.ic_history, "history")
+    )
 
     NavigationBar(
         modifier = modifier,

--- a/modules/design-system/src/main/res/values-ar/strings.xml
+++ b/modules/design-system/src/main/res/values-ar/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">البلوكشين</string>
+    <string name="design_menu_blockchain_fee_type">نوع الرسوم: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">عادي</string>
+    <string name="design_menu_currency_title">العملة</string>
+    <string name="design_menu_currency_default">دولار أمريكي</string>
+    <string name="design_menu_games_title">الألعاب</string>
+    <string name="design_menu_games_description">ميزات الترفيه</string>
+    <string name="design_menu_language_title">اللغة</string>
+    <string name="design_menu_language_default">الإنجليزية</string>
+    <string name="design_menu_lock_title">القفل</string>
+    <string name="design_menu_lock_description">قفل أمان التطبيق</string>
+    <string name="design_menu_security_title">الأمان</string>
+    <string name="design_menu_security_analytics_enabled">مشاركة التحليلات مفعلة</string>
+    <string name="design_menu_security_analytics_disabled">مشاركة التحليلات معطلة</string>
+    <string name="design_menu_social_media_title">وسائل التواصل الاجتماعي</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">الدعم</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">بيانات المزامنة</string>
+    <string name="design_menu_sync_metadata_no_data">لا توجد بيانات مزامنة</string>
+    <string name="design_menu_sync_metadata_last_sync">آخر مزامنة: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">لافتة التعلم</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">إرسال</string>
+    <string name="design_bottom_nav_buy_receive">شراء/استقبال</string>
+    <string name="design_bottom_nav_game_hub">مركز الألعاب</string>
+    <string name="design_bottom_nav_history">السجل</string>
+</resources>

--- a/modules/design-system/src/main/res/values-de/strings.xml
+++ b/modules/design-system/src/main/res/values-de/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Blockchain</string>
+    <string name="design_menu_blockchain_fee_type">Gebührenart: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Normal</string>
+    <string name="design_menu_currency_title">Währung</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">Spiele</string>
+    <string name="design_menu_games_description">Unterhaltungsfunktionen</string>
+    <string name="design_menu_language_title">Sprache</string>
+    <string name="design_menu_language_default">Englisch</string>
+    <string name="design_menu_lock_title">Sperre</string>
+    <string name="design_menu_lock_description">App-Sicherheitssperre</string>
+    <string name="design_menu_security_title">Sicherheit</string>
+    <string name="design_menu_security_analytics_enabled">Analyse-Freigabe aktiviert</string>
+    <string name="design_menu_security_analytics_disabled">Analyse-Freigabe deaktiviert</string>
+    <string name="design_menu_social_media_title">Soziale Medien</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">Support</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">Sync-Metadaten</string>
+    <string name="design_menu_sync_metadata_no_data">Keine Sync-Metadaten</string>
+    <string name="design_menu_sync_metadata_last_sync">Letzte Synchronisation: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Lern-Banner</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Senden</string>
+    <string name="design_bottom_nav_buy_receive">Kaufen/Empfangen</string>
+    <string name="design_bottom_nav_game_hub">Spiele-Hub</string>
+    <string name="design_bottom_nav_history">Verlauf</string>
+</resources>

--- a/modules/design-system/src/main/res/values-es/strings.xml
+++ b/modules/design-system/src/main/res/values-es/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Blockchain</string>
+    <string name="design_menu_blockchain_fee_type">Tipo de tarifa: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Regular</string>
+    <string name="design_menu_currency_title">Moneda</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">Juegos</string>
+    <string name="design_menu_games_description">Funciones de entretenimiento</string>
+    <string name="design_menu_language_title">Idioma</string>
+    <string name="design_menu_language_default">Inglés</string>
+    <string name="design_menu_lock_title">Bloqueo</string>
+    <string name="design_menu_lock_description">Bloqueo de seguridad de la aplicación</string>
+    <string name="design_menu_security_title">Seguridad</string>
+    <string name="design_menu_security_analytics_enabled">Compartir análisis habilitado</string>
+    <string name="design_menu_security_analytics_disabled">Compartir análisis deshabilitado</string>
+    <string name="design_menu_social_media_title">Redes Sociales</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">Soporte</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">Metadatos de Sincronización</string>
+    <string name="design_menu_sync_metadata_no_data">Sin metadatos de sincronización</string>
+    <string name="design_menu_sync_metadata_last_sync">Última sincronización: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Banner de Aprendizaje</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Enviar</string>
+    <string name="design_bottom_nav_buy_receive">Comprar/Recibir</string>
+    <string name="design_bottom_nav_game_hub">Centro de Juegos</string>
+    <string name="design_bottom_nav_history">Historial</string>
+</resources>

--- a/modules/design-system/src/main/res/values-fa/strings.xml
+++ b/modules/design-system/src/main/res/values-fa/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">بلاکچین</string>
+    <string name="design_menu_blockchain_fee_type">نوع کارمزد: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">معمولی</string>
+    <string name="design_menu_currency_title">ارز</string>
+    <string name="design_menu_currency_default">دلار آمریکا</string>
+    <string name="design_menu_games_title">بازی‌ها</string>
+    <string name="design_menu_games_description">ویژگی‌های سرگرمی</string>
+    <string name="design_menu_language_title">زبان</string>
+    <string name="design_menu_language_default">انگلیسی</string>
+    <string name="design_menu_lock_title">قفل</string>
+    <string name="design_menu_lock_description">قفل امنیتی برنامه</string>
+    <string name="design_menu_security_title">امنیت</string>
+    <string name="design_menu_security_analytics_enabled">اشتراک‌گذاری تحلیل‌ها فعال است</string>
+    <string name="design_menu_security_analytics_disabled">اشتراک‌گذاری تحلیل‌ها غیرفعال است</string>
+    <string name="design_menu_social_media_title">رسانه‌های اجتماعی</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">پشتیبانی</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">متادیتای همگام‌سازی</string>
+    <string name="design_menu_sync_metadata_no_data">بدون متادیتای همگام‌سازی</string>
+    <string name="design_menu_sync_metadata_last_sync">آخرین همگام‌سازی: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">بنر یادگیری</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">ارسال</string>
+    <string name="design_bottom_nav_buy_receive">خرید/دریافت</string>
+    <string name="design_bottom_nav_game_hub">مرکز بازی</string>
+    <string name="design_bottom_nav_history">تاریخچه</string>
+</resources>

--- a/modules/design-system/src/main/res/values-fr/strings.xml
+++ b/modules/design-system/src/main/res/values-fr/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Blockchain</string>
+    <string name="design_menu_blockchain_fee_type">Type de frais : %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Régulier</string>
+    <string name="design_menu_currency_title">Devise</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">Jeux</string>
+    <string name="design_menu_games_description">Fonctionnalités de divertissement</string>
+    <string name="design_menu_language_title">Langue</string>
+    <string name="design_menu_language_default">Anglais</string>
+    <string name="design_menu_lock_title">Verrouillage</string>
+    <string name="design_menu_lock_description">Verrouillage de sécurité de l\'application</string>
+    <string name="design_menu_security_title">Sécurité</string>
+    <string name="design_menu_security_analytics_enabled">Partage des analyses activé</string>
+    <string name="design_menu_security_analytics_disabled">Partage des analyses désactivé</string>
+    <string name="design_menu_social_media_title">Réseaux Sociaux</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">Support</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">Métadonnées de Synchronisation</string>
+    <string name="design_menu_sync_metadata_no_data">Aucune métadonnée de synchronisation</string>
+    <string name="design_menu_sync_metadata_last_sync">Dernière synchronisation : %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Bannière d\'Apprentissage</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Envoyer</string>
+    <string name="design_bottom_nav_buy_receive">Acheter/Recevoir</string>
+    <string name="design_bottom_nav_game_hub">Centre de Jeux</string>
+    <string name="design_bottom_nav_history">Historique</string>
+</resources>

--- a/modules/design-system/src/main/res/values-hi/strings.xml
+++ b/modules/design-system/src/main/res/values-hi/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">ब्लॉकचेन</string>
+    <string name="design_menu_blockchain_fee_type">शुल्क प्रकार: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">नियमित</string>
+    <string name="design_menu_currency_title">मुद्रा</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">खेल</string>
+    <string name="design_menu_games_description">मनोरंजन सुविधाएं</string>
+    <string name="design_menu_language_title">भाषा</string>
+    <string name="design_menu_language_default">अंग्रेज़ी</string>
+    <string name="design_menu_lock_title">लॉक</string>
+    <string name="design_menu_lock_description">ऐप सुरक्षा लॉक</string>
+    <string name="design_menu_security_title">सुरक्षा</string>
+    <string name="design_menu_security_analytics_enabled">विश्लेषण साझाकरण सक्षम</string>
+    <string name="design_menu_security_analytics_disabled">विश्लेषण साझाकरण अक्षम</string>
+    <string name="design_menu_social_media_title">सोशल मीडिया</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">सहायता</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">सिंक मेटाडेटा</string>
+    <string name="design_menu_sync_metadata_no_data">कोई सिंक मेटाडेटा नहीं</string>
+    <string name="design_menu_sync_metadata_last_sync">अंतिम सिंक: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">सीखने का बैनर</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">भेजें</string>
+    <string name="design_bottom_nav_buy_receive">खरीदें/प्राप्त करें</string>
+    <string name="design_bottom_nav_game_hub">गेम हब</string>
+    <string name="design_bottom_nav_history">इतिहास</string>
+</resources>

--- a/modules/design-system/src/main/res/values-in/strings.xml
+++ b/modules/design-system/src/main/res/values-in/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Blockchain</string>
+    <string name="design_menu_blockchain_fee_type">Jenis biaya: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Reguler</string>
+    <string name="design_menu_currency_title">Mata Uang</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">Permainan</string>
+    <string name="design_menu_games_description">Fitur hiburan</string>
+    <string name="design_menu_language_title">Bahasa</string>
+    <string name="design_menu_language_default">Inggris</string>
+    <string name="design_menu_lock_title">Kunci</string>
+    <string name="design_menu_lock_description">Kunci keamanan aplikasi</string>
+    <string name="design_menu_security_title">Keamanan</string>
+    <string name="design_menu_security_analytics_enabled">Berbagi analitik diaktifkan</string>
+    <string name="design_menu_security_analytics_disabled">Berbagi analitik dinonaktifkan</string>
+    <string name="design_menu_social_media_title">Media Sosial</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">Dukungan</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">Metadata Sinkronisasi</string>
+    <string name="design_menu_sync_metadata_no_data">Tidak ada metadata sinkronisasi</string>
+    <string name="design_menu_sync_metadata_last_sync">Sinkronisasi terakhir: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Banner Pembelajaran</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Kirim</string>
+    <string name="design_bottom_nav_buy_receive">Beli/Terima</string>
+    <string name="design_bottom_nav_game_hub">Pusat Game</string>
+    <string name="design_bottom_nav_history">Riwayat</string>
+</resources>

--- a/modules/design-system/src/main/res/values-it/strings.xml
+++ b/modules/design-system/src/main/res/values-it/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Blockchain</string>
+    <string name="design_menu_blockchain_fee_type">Tipo di commissione: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Regolare</string>
+    <string name="design_menu_currency_title">Valuta</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">Giochi</string>
+    <string name="design_menu_games_description">Funzionalità di intrattenimento</string>
+    <string name="design_menu_language_title">Lingua</string>
+    <string name="design_menu_language_default">Inglese</string>
+    <string name="design_menu_lock_title">Blocco</string>
+    <string name="design_menu_lock_description">Blocco di sicurezza dell\'app</string>
+    <string name="design_menu_security_title">Sicurezza</string>
+    <string name="design_menu_security_analytics_enabled">Condivisione analisi abilitata</string>
+    <string name="design_menu_security_analytics_disabled">Condivisione analisi disabilitata</string>
+    <string name="design_menu_social_media_title">Social Media</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">Supporto</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">Metadati di Sincronizzazione</string>
+    <string name="design_menu_sync_metadata_no_data">Nessun metadato di sincronizzazione</string>
+    <string name="design_menu_sync_metadata_last_sync">Ultima sincronizzazione: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Banner di Apprendimento</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Invia</string>
+    <string name="design_bottom_nav_buy_receive">Acquista/Ricevi</string>
+    <string name="design_bottom_nav_game_hub">Hub Giochi</string>
+    <string name="design_bottom_nav_history">Cronologia</string>
+</resources>

--- a/modules/design-system/src/main/res/values-ja/strings.xml
+++ b/modules/design-system/src/main/res/values-ja/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">ブロックチェーン</string>
+    <string name="design_menu_blockchain_fee_type">手数料タイプ: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">通常</string>
+    <string name="design_menu_currency_title">通貨</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">ゲーム</string>
+    <string name="design_menu_games_description">エンターテイメント機能</string>
+    <string name="design_menu_language_title">言語</string>
+    <string name="design_menu_language_default">英語</string>
+    <string name="design_menu_lock_title">ロック</string>
+    <string name="design_menu_lock_description">アプリセキュリティロック</string>
+    <string name="design_menu_security_title">セキュリティ</string>
+    <string name="design_menu_security_analytics_enabled">分析共有が有効</string>
+    <string name="design_menu_security_analytics_disabled">分析共有が無効</string>
+    <string name="design_menu_social_media_title">ソーシャルメディア</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">サポート</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">同期メタデータ</string>
+    <string name="design_menu_sync_metadata_no_data">同期メタデータなし</string>
+    <string name="design_menu_sync_metadata_last_sync">最終同期: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">学習バナー</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">送信</string>
+    <string name="design_bottom_nav_buy_receive">購入/受信</string>
+    <string name="design_bottom_nav_game_hub">ゲームハブ</string>
+    <string name="design_bottom_nav_history">履歴</string>
+</resources>

--- a/modules/design-system/src/main/res/values-ko/strings.xml
+++ b/modules/design-system/src/main/res/values-ko/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">블록체인</string>
+    <string name="design_menu_blockchain_fee_type">수수료 유형: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">일반</string>
+    <string name="design_menu_currency_title">통화</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">게임</string>
+    <string name="design_menu_games_description">엔터테인먼트 기능</string>
+    <string name="design_menu_language_title">언어</string>
+    <string name="design_menu_language_default">영어</string>
+    <string name="design_menu_lock_title">잠금</string>
+    <string name="design_menu_lock_description">앱 보안 잠금</string>
+    <string name="design_menu_security_title">보안</string>
+    <string name="design_menu_security_analytics_enabled">분석 공유 활성화됨</string>
+    <string name="design_menu_security_analytics_disabled">분석 공유 비활성화됨</string>
+    <string name="design_menu_social_media_title">소셜 미디어</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">지원</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">동기화 메타데이터</string>
+    <string name="design_menu_sync_metadata_no_data">동기화 메타데이터 없음</string>
+    <string name="design_menu_sync_metadata_last_sync">마지막 동기화: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">학습 배너</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">보내기</string>
+    <string name="design_bottom_nav_buy_receive">구매/받기</string>
+    <string name="design_bottom_nav_game_hub">게임 허브</string>
+    <string name="design_bottom_nav_history">기록</string>
+</resources>

--- a/modules/design-system/src/main/res/values-pa/strings.xml
+++ b/modules/design-system/src/main/res/values-pa/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">ਬਲਾਕਚੇਨ</string>
+    <string name="design_menu_blockchain_fee_type">ਫੀਸ ਦੀ ਕਿਸਮ: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">ਨਿਯਮਤ</string>
+    <string name="design_menu_currency_title">ਮੁਦਰਾ</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">ਖੇਡਾਂ</string>
+    <string name="design_menu_games_description">ਮਨੋਰੰਜਨ ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ</string>
+    <string name="design_menu_language_title">ਭਾਸ਼ਾ</string>
+    <string name="design_menu_language_default">ਅੰਗਰੇਜ਼ੀ</string>
+    <string name="design_menu_lock_title">ਲਾਕ</string>
+    <string name="design_menu_lock_description">ਐਪ ਸੁਰੱਖਿਆ ਲਾਕ</string>
+    <string name="design_menu_security_title">ਸੁਰੱਖਿਆ</string>
+    <string name="design_menu_security_analytics_enabled">ਵਿਸ਼ਲੇਸ਼ਣ ਸਾਂਝਾਕਰਨ ਸਮਰੱਥ</string>
+    <string name="design_menu_security_analytics_disabled">ਵਿਸ਼ਲੇਸ਼ਣ ਸਾਂਝਾਕਰਨ ਅਸਮਰੱਥ</string>
+    <string name="design_menu_social_media_title">ਸੋਸ਼ਲ ਮੀਡੀਆ</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">ਸਹਾਇਤਾ</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">ਸਿੰਕ ਮੈਟਾਡੇਟਾ</string>
+    <string name="design_menu_sync_metadata_no_data">ਕੋਈ ਸਿੰਕ ਮੈਟਾਡੇਟਾ ਨਹੀਂ</string>
+    <string name="design_menu_sync_metadata_last_sync">ਆਖਰੀ ਸਿੰਕ: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">ਸਿੱਖਣ ਦਾ ਬੈਨਰ</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">ਭੇਜੋ</string>
+    <string name="design_bottom_nav_buy_receive">ਖਰੀਦੋ/ਪ੍ਰਾਪਤ ਕਰੋ</string>
+    <string name="design_bottom_nav_game_hub">ਗੇਮ ਹੱਬ</string>
+    <string name="design_bottom_nav_history">ਇਤਿਹਾਸ</string>
+</resources>

--- a/modules/design-system/src/main/res/values-pl/strings.xml
+++ b/modules/design-system/src/main/res/values-pl/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Blockchain</string>
+    <string name="design_menu_blockchain_fee_type">Typ opłaty: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Zwykła</string>
+    <string name="design_menu_currency_title">Waluta</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">Gry</string>
+    <string name="design_menu_games_description">Funkcje rozrywkowe</string>
+    <string name="design_menu_language_title">Język</string>
+    <string name="design_menu_language_default">Angielski</string>
+    <string name="design_menu_lock_title">Blokada</string>
+    <string name="design_menu_lock_description">Blokada zabezpieczeń aplikacji</string>
+    <string name="design_menu_security_title">Bezpieczeństwo</string>
+    <string name="design_menu_security_analytics_enabled">Udostępnianie analiz włączone</string>
+    <string name="design_menu_security_analytics_disabled">Udostępnianie analiz wyłączone</string>
+    <string name="design_menu_social_media_title">Media Społecznościowe</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">Wsparcie</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">Metadane Synchronizacji</string>
+    <string name="design_menu_sync_metadata_no_data">Brak metadanych synchronizacji</string>
+    <string name="design_menu_sync_metadata_last_sync">Ostatnia synchronizacja: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Baner Nauki</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Wyślij</string>
+    <string name="design_bottom_nav_buy_receive">Kup/Odbierz</string>
+    <string name="design_bottom_nav_game_hub">Centrum Gier</string>
+    <string name="design_bottom_nav_history">Historia</string>
+</resources>

--- a/modules/design-system/src/main/res/values-pt/strings.xml
+++ b/modules/design-system/src/main/res/values-pt/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Blockchain</string>
+    <string name="design_menu_blockchain_fee_type">Tipo de taxa: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Regular</string>
+    <string name="design_menu_currency_title">Moeda</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">Jogos</string>
+    <string name="design_menu_games_description">Recursos de entretenimento</string>
+    <string name="design_menu_language_title">Idioma</string>
+    <string name="design_menu_language_default">Inglês</string>
+    <string name="design_menu_lock_title">Bloqueio</string>
+    <string name="design_menu_lock_description">Bloqueio de segurança do aplicativo</string>
+    <string name="design_menu_security_title">Segurança</string>
+    <string name="design_menu_security_analytics_enabled">Compartilhamento de análises ativado</string>
+    <string name="design_menu_security_analytics_disabled">Compartilhamento de análises desativado</string>
+    <string name="design_menu_social_media_title">Redes Sociais</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">Suporte</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">Metadados de Sincronização</string>
+    <string name="design_menu_sync_metadata_no_data">Sem metadados de sincronização</string>
+    <string name="design_menu_sync_metadata_last_sync">Última sincronização: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Banner de Aprendizagem</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Enviar</string>
+    <string name="design_bottom_nav_buy_receive">Comprar/Receber</string>
+    <string name="design_bottom_nav_game_hub">Centro de Jogos</string>
+    <string name="design_bottom_nav_history">Histórico</string>
+</resources>

--- a/modules/design-system/src/main/res/values-ru/strings.xml
+++ b/modules/design-system/src/main/res/values-ru/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Блокчейн</string>
+    <string name="design_menu_blockchain_fee_type">Тип комиссии: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Обычная</string>
+    <string name="design_menu_currency_title">Валюта</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">Игры</string>
+    <string name="design_menu_games_description">Развлекательные функции</string>
+    <string name="design_menu_language_title">Язык</string>
+    <string name="design_menu_language_default">Английский</string>
+    <string name="design_menu_lock_title">Блокировка</string>
+    <string name="design_menu_lock_description">Блокировка безопасности приложения</string>
+    <string name="design_menu_security_title">Безопасность</string>
+    <string name="design_menu_security_analytics_enabled">Обмен аналитикой включен</string>
+    <string name="design_menu_security_analytics_disabled">Обмен аналитикой отключен</string>
+    <string name="design_menu_social_media_title">Социальные Сети</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">Поддержка</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">Метаданные Синхронизации</string>
+    <string name="design_menu_sync_metadata_no_data">Нет метаданных синхронизации</string>
+    <string name="design_menu_sync_metadata_last_sync">Последняя синхронизация: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Баннер Обучения</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Отправить</string>
+    <string name="design_bottom_nav_buy_receive">Купить/Получить</string>
+    <string name="design_bottom_nav_game_hub">Игровой Центр</string>
+    <string name="design_bottom_nav_history">История</string>
+</resources>

--- a/modules/design-system/src/main/res/values-sv/strings.xml
+++ b/modules/design-system/src/main/res/values-sv/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Blockchain</string>
+    <string name="design_menu_blockchain_fee_type">Avgiftstyp: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Vanlig</string>
+    <string name="design_menu_currency_title">Valuta</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">Spel</string>
+    <string name="design_menu_games_description">Underhållningsfunktioner</string>
+    <string name="design_menu_language_title">Språk</string>
+    <string name="design_menu_language_default">Engelska</string>
+    <string name="design_menu_lock_title">Lås</string>
+    <string name="design_menu_lock_description">Appsäkerhetslås</string>
+    <string name="design_menu_security_title">Säkerhet</string>
+    <string name="design_menu_security_analytics_enabled">Analysdelning aktiverad</string>
+    <string name="design_menu_security_analytics_disabled">Analysdelning inaktiverad</string>
+    <string name="design_menu_social_media_title">Sociala Medier</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">Support</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">Synkroniseringsmetadata</string>
+    <string name="design_menu_sync_metadata_no_data">Ingen synkroniseringsmetadata</string>
+    <string name="design_menu_sync_metadata_last_sync">Senaste synkronisering: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Inlärningsbanner</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Skicka</string>
+    <string name="design_bottom_nav_buy_receive">Köp/Ta emot</string>
+    <string name="design_bottom_nav_game_hub">Spelhubb</string>
+    <string name="design_bottom_nav_history">Historik</string>
+</resources>

--- a/modules/design-system/src/main/res/values-tr/strings.xml
+++ b/modules/design-system/src/main/res/values-tr/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Blockchain</string>
+    <string name="design_menu_blockchain_fee_type">Ücret türü: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Normal</string>
+    <string name="design_menu_currency_title">Para Birimi</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">Oyunlar</string>
+    <string name="design_menu_games_description">Eğlence özellikleri</string>
+    <string name="design_menu_language_title">Dil</string>
+    <string name="design_menu_language_default">İngilizce</string>
+    <string name="design_menu_lock_title">Kilit</string>
+    <string name="design_menu_lock_description">Uygulama güvenlik kilidi</string>
+    <string name="design_menu_security_title">Güvenlik</string>
+    <string name="design_menu_security_analytics_enabled">Analiz paylaşımı etkin</string>
+    <string name="design_menu_security_analytics_disabled">Analiz paylaşımı devre dışı</string>
+    <string name="design_menu_social_media_title">Sosyal Medya</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">Destek</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">Senkronizasyon Meta Verileri</string>
+    <string name="design_menu_sync_metadata_no_data">Senkronizasyon meta verisi yok</string>
+    <string name="design_menu_sync_metadata_last_sync">Son senkronizasyon: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Öğrenme Afişi</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Gönder</string>
+    <string name="design_bottom_nav_buy_receive">Satın Al/Al</string>
+    <string name="design_bottom_nav_game_hub">Oyun Merkezi</string>
+    <string name="design_bottom_nav_history">Geçmiş</string>
+</resources>

--- a/modules/design-system/src/main/res/values-uk/strings.xml
+++ b/modules/design-system/src/main/res/values-uk/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Блокчейн</string>
+    <string name="design_menu_blockchain_fee_type">Тип комісії: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Звичайна</string>
+    <string name="design_menu_currency_title">Валюта</string>
+    <string name="design_menu_currency_default">USD</string>
+    <string name="design_menu_games_title">Ігри</string>
+    <string name="design_menu_games_description">Розважальні функції</string>
+    <string name="design_menu_language_title">Мова</string>
+    <string name="design_menu_language_default">Англійська</string>
+    <string name="design_menu_lock_title">Блокування</string>
+    <string name="design_menu_lock_description">Блокування безпеки додатка</string>
+    <string name="design_menu_security_title">Безпека</string>
+    <string name="design_menu_security_analytics_enabled">Обмін аналітикою увімкнено</string>
+    <string name="design_menu_security_analytics_disabled">Обмін аналітикою вимкнено</string>
+    <string name="design_menu_social_media_title">Соціальні Мережі</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">Підтримка</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">Метадані Синхронізації</string>
+    <string name="design_menu_sync_metadata_no_data">Немає метаданих синхронізації</string>
+    <string name="design_menu_sync_metadata_last_sync">Остання синхронізація: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Банер Навчання</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Надіслати</string>
+    <string name="design_bottom_nav_buy_receive">Купити/Отримати</string>
+    <string name="design_bottom_nav_game_hub">Ігровий Центр</string>
+    <string name="design_bottom_nav_history">Історія</string>
+</resources>

--- a/modules/design-system/src/main/res/values-zh-rCN/strings.xml
+++ b/modules/design-system/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">区块链</string>
+    <string name="design_menu_blockchain_fee_type">费用类型：%1$s</string>
+    <string name="design_menu_blockchain_fee_regular">常规</string>
+    <string name="design_menu_currency_title">货币</string>
+    <string name="design_menu_currency_default">美元</string>
+    <string name="design_menu_games_title">游戏</string>
+    <string name="design_menu_games_description">娱乐功能</string>
+    <string name="design_menu_language_title">语言</string>
+    <string name="design_menu_language_default">英语</string>
+    <string name="design_menu_lock_title">锁定</string>
+    <string name="design_menu_lock_description">应用安全锁</string>
+    <string name="design_menu_security_title">安全</string>
+    <string name="design_menu_security_analytics_enabled">已启用分析共享</string>
+    <string name="design_menu_security_analytics_disabled">已禁用分析共享</string>
+    <string name="design_menu_social_media_title">社交媒体</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">支持</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">同步元数据</string>
+    <string name="design_menu_sync_metadata_no_data">无同步元数据</string>
+    <string name="design_menu_sync_metadata_last_sync">上次同步：%1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">学习横幅</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">发送</string>
+    <string name="design_bottom_nav_buy_receive">购买/接收</string>
+    <string name="design_bottom_nav_game_hub">游戏中心</string>
+    <string name="design_bottom_nav_history">历史</string>
+</resources>

--- a/modules/design-system/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/design-system/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">區塊鏈</string>
+    <string name="design_menu_blockchain_fee_type">費用類型：%1$s</string>
+    <string name="design_menu_blockchain_fee_regular">常規</string>
+    <string name="design_menu_currency_title">貨幣</string>
+    <string name="design_menu_currency_default">美元</string>
+    <string name="design_menu_games_title">遊戲</string>
+    <string name="design_menu_games_description">娛樂功能</string>
+    <string name="design_menu_language_title">語言</string>
+    <string name="design_menu_language_default">英語</string>
+    <string name="design_menu_lock_title">鎖定</string>
+    <string name="design_menu_lock_description">應用程式安全鎖</string>
+    <string name="design_menu_security_title">安全</string>
+    <string name="design_menu_security_analytics_enabled">已啟用分析共享</string>
+    <string name="design_menu_security_analytics_disabled">已停用分析共享</string>
+    <string name="design_menu_social_media_title">社群媒體</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    <string name="design_menu_support_title">支援</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    <string name="design_menu_sync_metadata_title">同步中繼資料</string>
+    <string name="design_menu_sync_metadata_no_data">無同步中繼資料</string>
+    <string name="design_menu_sync_metadata_last_sync">上次同步：%1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">學習橫幅</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">發送</string>
+    <string name="design_bottom_nav_buy_receive">購買/接收</string>
+    <string name="design_bottom_nav_game_hub">遊戲中心</string>
+    <string name="design_bottom_nav_history">歷史</string>
+</resources>

--- a/modules/design-system/src/main/res/values/strings.xml
+++ b/modules/design-system/src/main/res/values/strings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: design-system -->
+    
+    <!-- Menu Components -->
+    <string name="design_menu_blockchain_title">Blockchain</string>
+    <string name="design_menu_blockchain_fee_type">Fee type: %1$s</string>
+    <string name="design_menu_blockchain_fee_regular">Regular</string>
+    
+    <string name="design_menu_currency_title">Currency</string>
+    <string name="design_menu_currency_default">USD</string>
+    
+    <string name="design_menu_games_title">Games</string>
+    <string name="design_menu_games_description">Entertainment features</string>
+    
+    <string name="design_menu_language_title">Language</string>
+    <string name="design_menu_language_default">English</string>
+    
+    <string name="design_menu_lock_title">Lock</string>
+    <string name="design_menu_lock_description">App security lock</string>
+    
+    <string name="design_menu_security_title">Security</string>
+    <string name="design_menu_security_analytics_enabled">Analytics sharing enabled</string>
+    <string name="design_menu_security_analytics_disabled">Analytics sharing disabled</string>
+    
+    <string name="design_menu_social_media_title">Social Media</string>
+    <string name="design_menu_social_media_link" translatable="false">linktr.ee/brainwallet</string>
+    
+    <string name="design_menu_support_title">Support</string>
+    <string name="design_menu_support_link" translatable="false">brainwallet.co/support.html</string>
+    
+    <string name="design_menu_sync_metadata_title">Sync Metadata</string>
+    <string name="design_menu_sync_metadata_no_data">No sync metadata</string>
+    <string name="design_menu_sync_metadata_last_sync">Last sync: %1$s</string>
+    
+    <!-- Rail Components -->
+    <string name="design_rail_learning_banner_text">Learning Banner</string>
+    
+    <!-- Bottom Navigation -->
+    <string name="design_bottom_nav_send">Send</string>
+    <string name="design_bottom_nav_buy_receive">Buy/Receive</string>
+    <string name="design_bottom_nav_game_hub">Game Hub</string>
+    <string name="design_bottom_nav_history">History</string>
+</resources>

--- a/modules/gamehub/build.gradle.kts
+++ b/modules/gamehub/build.gradle.kts
@@ -21,6 +21,11 @@ android {
         minSdk = 29
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        
+        resourceConfigurations += listOf(
+            "en", "ar", "de", "es", "fa", "fr", "hi", "in", "it", "ja",
+            "ko", "pa", "pl", "pt", "ru", "sv", "tr", "uk", "zh-rCN", "zh-rTW"
+        )
     }
 
     buildTypes {

--- a/modules/gamehub/src/main/java/com/brainwallet/gamehub/presentation/component/GameHubGrid.kt
+++ b/modules/gamehub/src/main/java/com/brainwallet/gamehub/presentation/component/GameHubGrid.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -56,7 +57,7 @@ fun GameHubGrid(
                 val currentGames = games[page]
                 Image(
                     painter = painterResource(currentGames.banner),
-                    contentDescription = "Game Banner",
+                    contentDescription = stringResource(R.string.gamehub_grid_banner_content_description),
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop
                 )
@@ -77,7 +78,7 @@ fun GameHubGrid(
                 }
             }
             GridChip(
-                "Game Hub",
+                stringResource(R.string.gamehub_grid_chip_label),
                 modifier = Modifier
                     .align(Alignment.TopStart)
                     .padding(8.dp)

--- a/modules/gamehub/src/main/res/values-ar/strings.xml
+++ b/modules/gamehub/src/main/res/values-ar/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">مركز الألعاب</string>
+    <string name="gamehub_grid_banner_content_description">لافتة اللعبة</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-de/strings.xml
+++ b/modules/gamehub/src/main/res/values-de/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Spiele-Hub</string>
+    <string name="gamehub_grid_banner_content_description">Spiel-Banner</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-es/strings.xml
+++ b/modules/gamehub/src/main/res/values-es/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Centro de Juegos</string>
+    <string name="gamehub_grid_banner_content_description">Banner del Juego</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-fa/strings.xml
+++ b/modules/gamehub/src/main/res/values-fa/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">مرکز بازی</string>
+    <string name="gamehub_grid_banner_content_description">بنر بازی</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-fr/strings.xml
+++ b/modules/gamehub/src/main/res/values-fr/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Centre de Jeux</string>
+    <string name="gamehub_grid_banner_content_description">Bannière de Jeu</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-hi/strings.xml
+++ b/modules/gamehub/src/main/res/values-hi/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">गेम हब</string>
+    <string name="gamehub_grid_banner_content_description">गेम बैनर</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-in/strings.xml
+++ b/modules/gamehub/src/main/res/values-in/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Pusat Permainan</string>
+    <string name="gamehub_grid_banner_content_description">Banner Permainan</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-it/strings.xml
+++ b/modules/gamehub/src/main/res/values-it/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Hub Giochi</string>
+    <string name="gamehub_grid_banner_content_description">Banner del Gioco</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-ja/strings.xml
+++ b/modules/gamehub/src/main/res/values-ja/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">ゲームハブ</string>
+    <string name="gamehub_grid_banner_content_description">ゲームバナー</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-ko/strings.xml
+++ b/modules/gamehub/src/main/res/values-ko/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">게임 허브</string>
+    <string name="gamehub_grid_banner_content_description">게임 배너</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-pa/strings.xml
+++ b/modules/gamehub/src/main/res/values-pa/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">ਗੇਮ ਹੱਬ</string>
+    <string name="gamehub_grid_banner_content_description">ਗੇਮ ਬੈਨਰ</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-pl/strings.xml
+++ b/modules/gamehub/src/main/res/values-pl/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Centrum Gier</string>
+    <string name="gamehub_grid_banner_content_description">Baner Gry</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-pt/strings.xml
+++ b/modules/gamehub/src/main/res/values-pt/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Centro de Jogos</string>
+    <string name="gamehub_grid_banner_content_description">Banner do Jogo</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-ru/strings.xml
+++ b/modules/gamehub/src/main/res/values-ru/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Игровой Центр</string>
+    <string name="gamehub_grid_banner_content_description">Баннер Игры</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-sv/strings.xml
+++ b/modules/gamehub/src/main/res/values-sv/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Spelcentrum</string>
+    <string name="gamehub_grid_banner_content_description">Spelbanner</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-tr/strings.xml
+++ b/modules/gamehub/src/main/res/values-tr/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Oyun Merkezi</string>
+    <string name="gamehub_grid_banner_content_description">Oyun Afişi</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-uk/strings.xml
+++ b/modules/gamehub/src/main/res/values-uk/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Ігровий Центр</string>
+    <string name="gamehub_grid_banner_content_description">Банер Гри</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-zh-rCN/strings.xml
+++ b/modules/gamehub/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">游戏中心</string>
+    <string name="gamehub_grid_banner_content_description">游戏横幅</string>
+</resources>

--- a/modules/gamehub/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/gamehub/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">遊戲中心</string>
+    <string name="gamehub_grid_banner_content_description">遊戲橫幅</string>
+</resources>

--- a/modules/gamehub/src/main/res/values/strings.xml
+++ b/modules/gamehub/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: gamehub -->
+    
+    <!-- Grid Components -->
+    <string name="gamehub_grid_chip_label">Game Hub</string>
+    <string name="gamehub_grid_banner_content_description">Game Banner</string>
+</resources>

--- a/modules/ltc/build.gradle.kts
+++ b/modules/ltc/build.gradle.kts
@@ -21,6 +21,11 @@ android {
         minSdk = 29
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        
+        resourceConfigurations += listOf(
+            "en", "ar", "de", "es", "fa", "fr", "hi", "in", "it", "ja",
+            "ko", "pa", "pl", "pt", "ru", "sv", "tr", "uk", "zh-rCN", "zh-rTW"
+        )
     }
 
     buildTypes {

--- a/modules/ltc/src/main/java/com/brainwallet/ltc/presentation/component/FavoriteGrid.kt
+++ b/modules/ltc/src/main/java/com/brainwallet/ltc/presentation/component/FavoriteGrid.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -28,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.brainwallet.design.presentation.component.effect.CardOpacityContainer
 import com.brainwallet.design.presentation.component.widget.GridChip
+import com.brainwallet.ltc.R
 import com.brainwallet.design.R as DesignR
 import com.grunt.brainwallet.core.presentation.theme.BrainwalletTheme
 import com.grunt.brainwallet.core.presentation.theme.blue
@@ -55,7 +57,7 @@ fun FavoriteGrid(
                 .padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            GridChip("TOP SECRET", modifier = Modifier.padding(bottom = 3.dp))
+            GridChip(stringResource(R.string.ltc_favorite_chip_label), modifier = Modifier.padding(bottom = 3.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(-16.dp),
@@ -119,7 +121,7 @@ private fun AddContactButton(
     ) {
         Icon(
             painter = painterResource(id = DesignR.drawable.ic_plus),
-            contentDescription = "Add favorite contact",
+            contentDescription = stringResource(R.string.ltc_favorite_add_contact_description),
             tint = BrainwalletTheme.colors.content.copy(alpha = 0.7f),
             modifier = Modifier.size(16.dp)
         )

--- a/modules/ltc/src/main/java/com/brainwallet/ltc/presentation/component/balance/BalanceBentoGrid.kt
+++ b/modules/ltc/src/main/java/com/brainwallet/ltc/presentation/component/balance/BalanceBentoGrid.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -129,7 +130,7 @@ private fun HeaderSection(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = "YOUR BALANCE",
+            text = stringResource(R.string.ltc_balance_header_title),
             style = BrainwalletTheme.typography.labelMedium.copy(
                 color = Color.White,
                 fontWeight = FontWeight.SemiBold
@@ -148,7 +149,11 @@ private fun HeaderSection(
                         DesignR.drawable.ic_eye_disabled
                     }
                 ),
-                contentDescription = if (isBalanceVisible) "Hide balance" else "Show balance",
+                contentDescription = if (isBalanceVisible) {
+                    stringResource(R.string.ltc_balance_hide_content_description)
+                } else {
+                    stringResource(R.string.ltc_balance_show_content_description)
+                },
                 tint = Color.White,
                 modifier = Modifier.size(20.dp)
             )
@@ -184,7 +189,7 @@ private fun BalanceSection(
             ) {
                 Image(
                     painter = painterResource(id = R.drawable.ic_ltc),
-                    contentDescription = "Litecoin",
+                    contentDescription = stringResource(R.string.ltc_balance_litecoin_content_description),
                     modifier = Modifier.size(24.dp),
                     colorFilter = ColorFilter.tint(Color.White)
                 )

--- a/modules/ltc/src/main/java/com/brainwallet/ltc/presentation/component/balance/BalanceBentoSyncDetails.kt
+++ b/modules/ltc/src/main/java/com/brainwallet/ltc/presentation/component/balance/BalanceBentoSyncDetails.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -46,7 +47,7 @@ fun BalanceBentoSyncDetails(
         AnimatedVisibility(syncingState != null) {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
-                    text = "Syncing...",
+                    text = stringResource(R.string.ltc_sync_syncing_status),
                     modifier = Modifier.fillMaxWidth(),
                     style = BrainwalletTheme.typography.bodyMedium.copy(
                         color = Color.White,
@@ -55,7 +56,7 @@ fun BalanceBentoSyncDetails(
                     )
                 )
                 Text(
-                    "Last block: ${uiState.lastBlock}",
+                    stringResource(R.string.ltc_sync_last_block, uiState.lastBlock),
                     modifier = Modifier.fillMaxWidth(),
                     style = BrainwalletTheme.typography.bodyMedium.copy(
                         color = Color.White.copy(alpha = 0.6f),
@@ -64,7 +65,7 @@ fun BalanceBentoSyncDetails(
                     )
                 )
                 Text(
-                    "Date: ${syncingState?.timeStamp}",
+                    stringResource(R.string.ltc_sync_date, syncingState?.timeStamp ?: ""),
                     modifier = Modifier.fillMaxWidth(),
                     style = BrainwalletTheme.typography.bodyMedium.copy(
                         color = Color.White.copy(alpha = 0.6f),
@@ -82,7 +83,10 @@ fun BalanceBentoSyncDetails(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = "${((syncingState?.progress ?: (0 * 100))).toInt()}%",
+                        text = stringResource(
+                            R.string.ltc_sync_progress_percentage,
+                            ((syncingState?.progress ?: (0 * 100))).toInt()
+                        ),
                         style = BrainwalletTheme.typography.titleLarge.copy(
                             color = Color.White,
                             fontWeight = FontWeight.Bold
@@ -91,7 +95,10 @@ fun BalanceBentoSyncDetails(
 
                     if ((syncingState?.currentBlockHeight ?: 0) > 0) {
                         Text(
-                            text = "Block: ${syncingState?.currentBlockHeight}",
+                            text = stringResource(
+                                R.string.ltc_sync_block_height,
+                                syncingState?.currentBlockHeight ?: 0
+                            ),
                             style = BrainwalletTheme.typography.bodyMedium.copy(
                                 color = Color.White.copy(alpha = 0.6f)
                             )
@@ -128,7 +135,7 @@ private fun ActionButtonsSection(
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         ActionButton(
-            text = "Send",
+            text = stringResource(R.string.ltc_sync_action_send),
             iconRes = R.drawable.ic_send,
             iconTint = chili,
             onClick = onSendClick
@@ -137,7 +144,7 @@ private fun ActionButtonsSection(
         VerticalDivider()
 
         ActionButton(
-            text = "Receive",
+            text = stringResource(R.string.ltc_sync_action_receive),
             iconRes = R.drawable.ic_receive,
             iconTint = pesto,
             onClick = onReceiveClick

--- a/modules/ltc/src/main/java/com/brainwallet/ltc/presentation/component/transactionhistory/TransactionHistoryGrid.kt
+++ b/modules/ltc/src/main/java/com/brainwallet/ltc/presentation/component/transactionhistory/TransactionHistoryGrid.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -77,7 +78,7 @@ fun TransactionHistoryGrid(
             ) {
                 Icon(
                     painter = painterResource(R.drawable.launch),
-                    contentDescription = "Export",
+                    contentDescription = stringResource(R.string.ltc_transaction_export_content_description),
                     modifier = Modifier
                         .size(32.dp)
                         .padding(6.dp),
@@ -91,7 +92,7 @@ fun TransactionHistoryGrid(
                 .padding(vertical = 20.dp),
         ) {
             Text(
-                text = "TRANSACTION HISTORY",
+                text = stringResource(R.string.ltc_transaction_history_title),
                 style = BrainwalletTheme.typography.titleMedium.copy(
                     color = BrainwalletTheme.colors.content,
                     fontWeight = FontWeight.Bold
@@ -103,7 +104,7 @@ fun TransactionHistoryGrid(
 
             if (transactions.isEmpty()) {
                 Text(
-                    text = "No transactions yet",
+                    text = stringResource(R.string.ltc_transaction_history_empty),
                     style = BrainwalletTheme.typography.bodyMedium.copy(
                         color = BrainwalletTheme.colors.content.copy(alpha = 0.6f),
                         fontWeight = FontWeight.Normal
@@ -176,10 +177,10 @@ private fun TransactionItem(
     }
 
     val addressText = transaction.from.firstOrNull { it.isNotEmpty() }?.let { address ->
-        "from ${address.take(12)}...${address.takeLast(8)}"
+        stringResource(R.string.ltc_transaction_from_address, "${address.take(12)}...${address.takeLast(8)}")
     } ?: transaction.to.firstOrNull { it.isNotEmpty() }?.let { address ->
-        "to ${address.take(12)}...${address.takeLast(8)}"
-    } ?: "unknown"
+        stringResource(R.string.ltc_transaction_to_address, "${address.take(12)}...${address.takeLast(8)}")
+    } ?: stringResource(R.string.ltc_transaction_unknown_address)
 
     Row(
         modifier = modifier
@@ -215,7 +216,11 @@ private fun TransactionItem(
                             DesignR.drawable.mtrl_ic_arrow_drop_down
                         }
                     ),
-                    contentDescription = if (isReceived) "Received" else "Sent",
+                    contentDescription = if (isReceived) {
+                        stringResource(R.string.ltc_transaction_received_content_description)
+                    } else {
+                        stringResource(R.string.ltc_transaction_sent_content_description)
+                    },
                     tint = if (isReceived) {
                         BrainwalletTheme.colors.affirm
                     } else {

--- a/modules/ltc/src/main/res/values-ar/strings.xml
+++ b/modules/ltc/src/main/res/values-ar/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">رصيدك</string>
+    <string name="ltc_balance_hide_content_description">إخفاء الرصيد</string>
+    <string name="ltc_balance_show_content_description">إظهار الرصيد</string>
+    <string name="ltc_balance_litecoin_content_description">لايتكوين</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">جارٍ المزامنة…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">الكتلة: %1$d</string>
+    <string name="ltc_sync_last_block">آخر كتلة: %1$s</string>
+    <string name="ltc_sync_date">التاريخ: %1$s</string>
+    <string name="ltc_sync_action_send">إرسال</string>
+    <string name="ltc_sync_action_receive">استقبال</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">سجل المعاملات</string>
+    <string name="ltc_transaction_history_empty">لا توجد معاملات بعد</string>
+    <string name="ltc_transaction_export_content_description">تصدير</string>
+    <string name="ltc_transaction_received_content_description">مستلم</string>
+    <string name="ltc_transaction_sent_content_description">مرسل</string>
+    <string name="ltc_transaction_from_address">من %1$s</string>
+    <string name="ltc_transaction_to_address">إلى %1$s</string>
+    <string name="ltc_transaction_unknown_address">غير معروف</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">سري للغاية</string>
+    <string name="ltc_favorite_add_contact_description">إضافة جهة اتصال مفضلة</string>
+</resources>

--- a/modules/ltc/src/main/res/values-de/strings.xml
+++ b/modules/ltc/src/main/res/values-de/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">IHR GUTHABEN</string>
+    <string name="ltc_balance_hide_content_description">Guthaben ausblenden</string>
+    <string name="ltc_balance_show_content_description">Guthaben anzeigen</string>
+    <string name="ltc_balance_litecoin_content_description">Litecoin</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Synchronisierung…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Block: %1$d</string>
+    <string name="ltc_sync_last_block">Letzter Block: %1$s</string>
+    <string name="ltc_sync_date">Datum: %1$s</string>
+    <string name="ltc_sync_action_send">Senden</string>
+    <string name="ltc_sync_action_receive">Empfangen</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">TRANSAKTIONSVERLAUF</string>
+    <string name="ltc_transaction_history_empty">Noch keine Transaktionen</string>
+    <string name="ltc_transaction_export_content_description">Exportieren</string>
+    <string name="ltc_transaction_received_content_description">Empfangen</string>
+    <string name="ltc_transaction_sent_content_description">Gesendet</string>
+    <string name="ltc_transaction_from_address">von %1$s</string>
+    <string name="ltc_transaction_to_address">an %1$s</string>
+    <string name="ltc_transaction_unknown_address">unbekannt</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">STRENG GEHEIM</string>
+    <string name="ltc_favorite_add_contact_description">Favoritenkontakt hinzufügen</string>
+</resources>

--- a/modules/ltc/src/main/res/values-es/strings.xml
+++ b/modules/ltc/src/main/res/values-es/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">TU SALDO</string>
+    <string name="ltc_balance_hide_content_description">Ocultar saldo</string>
+    <string name="ltc_balance_show_content_description">Mostrar saldo</string>
+    <string name="ltc_balance_litecoin_content_description">Litecoin</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Sincronizando…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Bloque: %1$d</string>
+    <string name="ltc_sync_last_block">Último bloque: %1$s</string>
+    <string name="ltc_sync_date">Fecha: %1$s</string>
+    <string name="ltc_sync_action_send">Enviar</string>
+    <string name="ltc_sync_action_receive">Recibir</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">HISTORIAL DE TRANSACCIONES</string>
+    <string name="ltc_transaction_history_empty">Aún no hay transacciones</string>
+    <string name="ltc_transaction_export_content_description">Exportar</string>
+    <string name="ltc_transaction_received_content_description">Recibido</string>
+    <string name="ltc_transaction_sent_content_description">Enviado</string>
+    <string name="ltc_transaction_from_address">de %1$s</string>
+    <string name="ltc_transaction_to_address">a %1$s</string>
+    <string name="ltc_transaction_unknown_address">desconocido</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">ALTO SECRETO</string>
+    <string name="ltc_favorite_add_contact_description">Agregar contacto favorito</string>
+</resources>

--- a/modules/ltc/src/main/res/values-fa/strings.xml
+++ b/modules/ltc/src/main/res/values-fa/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">موجودی شما</string>
+    <string name="ltc_balance_hide_content_description">مخفی کردن موجودی</string>
+    <string name="ltc_balance_show_content_description">نمایش موجودی</string>
+    <string name="ltc_balance_litecoin_content_description">لایت‌کوین</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">در حال همگام‌سازی…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">بلوک: %1$d</string>
+    <string name="ltc_sync_last_block">آخرین بلوک: %1$s</string>
+    <string name="ltc_sync_date">تاریخ: %1$s</string>
+    <string name="ltc_sync_action_send">ارسال</string>
+    <string name="ltc_sync_action_receive">دریافت</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">تاریخچه تراکنش‌ها</string>
+    <string name="ltc_transaction_history_empty">هنوز تراکنشی وجود ندارد</string>
+    <string name="ltc_transaction_export_content_description">صادرات</string>
+    <string name="ltc_transaction_received_content_description">دریافت شده</string>
+    <string name="ltc_transaction_sent_content_description">ارسال شده</string>
+    <string name="ltc_transaction_from_address">از %1$s</string>
+    <string name="ltc_transaction_to_address">به %1$s</string>
+    <string name="ltc_transaction_unknown_address">ناشناس</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">فوق محرمانه</string>
+    <string name="ltc_favorite_add_contact_description">افزودن مخاطب مورد علاقه</string>
+</resources>

--- a/modules/ltc/src/main/res/values-fr/strings.xml
+++ b/modules/ltc/src/main/res/values-fr/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">VOTRE SOLDE</string>
+    <string name="ltc_balance_hide_content_description">Masquer le solde</string>
+    <string name="ltc_balance_show_content_description">Afficher le solde</string>
+    <string name="ltc_balance_litecoin_content_description">Litecoin</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Synchronisation…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Bloc : %1$d</string>
+    <string name="ltc_sync_last_block">Dernier bloc : %1$s</string>
+    <string name="ltc_sync_date">Date : %1$s</string>
+    <string name="ltc_sync_action_send">Envoyer</string>
+    <string name="ltc_sync_action_receive">Recevoir</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">HISTORIQUE DES TRANSACTIONS</string>
+    <string name="ltc_transaction_history_empty">Aucune transaction pour le moment</string>
+    <string name="ltc_transaction_export_content_description">Exporter</string>
+    <string name="ltc_transaction_received_content_description">Reçu</string>
+    <string name="ltc_transaction_sent_content_description">Envoyé</string>
+    <string name="ltc_transaction_from_address">de %1$s</string>
+    <string name="ltc_transaction_to_address">à %1$s</string>
+    <string name="ltc_transaction_unknown_address">inconnu</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">TOP SECRET</string>
+    <string name="ltc_favorite_add_contact_description">Ajouter un contact favori</string>
+</resources>

--- a/modules/ltc/src/main/res/values-hi/strings.xml
+++ b/modules/ltc/src/main/res/values-hi/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">आपका शेष</string>
+    <string name="ltc_balance_hide_content_description">शेष छिपाएं</string>
+    <string name="ltc_balance_show_content_description">शेष दिखाएं</string>
+    <string name="ltc_balance_litecoin_content_description">लाइटकॉइन</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">सिंक हो रहा है…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">ब्लॉक: %1$d</string>
+    <string name="ltc_sync_last_block">अंतिम ब्लॉक: %1$s</string>
+    <string name="ltc_sync_date">तारीख: %1$s</string>
+    <string name="ltc_sync_action_send">भेजें</string>
+    <string name="ltc_sync_action_receive">प्राप्त करें</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">लेनदेन इतिहास</string>
+    <string name="ltc_transaction_history_empty">अभी तक कोई लेनदेन नहीं</string>
+    <string name="ltc_transaction_export_content_description">निर्यात करें</string>
+    <string name="ltc_transaction_received_content_description">प्राप्त</string>
+    <string name="ltc_transaction_sent_content_description">भेजा गया</string>
+    <string name="ltc_transaction_from_address">%1$s से</string>
+    <string name="ltc_transaction_to_address">%1$s को</string>
+    <string name="ltc_transaction_unknown_address">अज्ञात</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">अति गोपनीय</string>
+    <string name="ltc_favorite_add_contact_description">पसंदीदा संपर्क जोड़ें</string>
+</resources>

--- a/modules/ltc/src/main/res/values-in/strings.xml
+++ b/modules/ltc/src/main/res/values-in/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">SALDO ANDA</string>
+    <string name="ltc_balance_hide_content_description">Sembunyikan saldo</string>
+    <string name="ltc_balance_show_content_description">Tampilkan saldo</string>
+    <string name="ltc_balance_litecoin_content_description">Litecoin</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Menyinkronkan…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Blok: %1$d</string>
+    <string name="ltc_sync_last_block">Blok terakhir: %1$s</string>
+    <string name="ltc_sync_date">Tanggal: %1$s</string>
+    <string name="ltc_sync_action_send">Kirim</string>
+    <string name="ltc_sync_action_receive">Terima</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">RIWAYAT TRANSAKSI</string>
+    <string name="ltc_transaction_history_empty">Belum ada transaksi</string>
+    <string name="ltc_transaction_export_content_description">Ekspor</string>
+    <string name="ltc_transaction_received_content_description">Diterima</string>
+    <string name="ltc_transaction_sent_content_description">Terkirim</string>
+    <string name="ltc_transaction_from_address">dari %1$s</string>
+    <string name="ltc_transaction_to_address">ke %1$s</string>
+    <string name="ltc_transaction_unknown_address">tidak diketahui</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">SANGAT RAHASIA</string>
+    <string name="ltc_favorite_add_contact_description">Tambah kontak favorit</string>
+</resources>

--- a/modules/ltc/src/main/res/values-it/strings.xml
+++ b/modules/ltc/src/main/res/values-it/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">IL TUO SALDO</string>
+    <string name="ltc_balance_hide_content_description">Nascondi saldo</string>
+    <string name="ltc_balance_show_content_description">Mostra saldo</string>
+    <string name="ltc_balance_litecoin_content_description">Litecoin</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Sincronizzazione…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Blocco: %1$d</string>
+    <string name="ltc_sync_last_block">Ultimo blocco: %1$s</string>
+    <string name="ltc_sync_date">Data: %1$s</string>
+    <string name="ltc_sync_action_send">Invia</string>
+    <string name="ltc_sync_action_receive">Ricevi</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">CRONOLOGIA TRANSAZIONI</string>
+    <string name="ltc_transaction_history_empty">Nessuna transazione ancora</string>
+    <string name="ltc_transaction_export_content_description">Esporta</string>
+    <string name="ltc_transaction_received_content_description">Ricevuto</string>
+    <string name="ltc_transaction_sent_content_description">Inviato</string>
+    <string name="ltc_transaction_from_address">da %1$s</string>
+    <string name="ltc_transaction_to_address">a %1$s</string>
+    <string name="ltc_transaction_unknown_address">sconosciuto</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">TOP SECRET</string>
+    <string name="ltc_favorite_add_contact_description">Aggiungi contatto preferito</string>
+</resources>

--- a/modules/ltc/src/main/res/values-ja/strings.xml
+++ b/modules/ltc/src/main/res/values-ja/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">残高</string>
+    <string name="ltc_balance_hide_content_description">残高を非表示</string>
+    <string name="ltc_balance_show_content_description">残高を表示</string>
+    <string name="ltc_balance_litecoin_content_description">ライトコイン</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">同期中…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">ブロック: %1$d</string>
+    <string name="ltc_sync_last_block">最終ブロック: %1$s</string>
+    <string name="ltc_sync_date">日付: %1$s</string>
+    <string name="ltc_sync_action_send">送信</string>
+    <string name="ltc_sync_action_receive">受信</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">取引履歴</string>
+    <string name="ltc_transaction_history_empty">まだ取引がありません</string>
+    <string name="ltc_transaction_export_content_description">エクスポート</string>
+    <string name="ltc_transaction_received_content_description">受信済み</string>
+    <string name="ltc_transaction_sent_content_description">送信済み</string>
+    <string name="ltc_transaction_from_address">%1$sから</string>
+    <string name="ltc_transaction_to_address">%1$sへ</string>
+    <string name="ltc_transaction_unknown_address">不明</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">極秘</string>
+    <string name="ltc_favorite_add_contact_description">お気に入りの連絡先を追加</string>
+</resources>

--- a/modules/ltc/src/main/res/values-ko/strings.xml
+++ b/modules/ltc/src/main/res/values-ko/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">잔액</string>
+    <string name="ltc_balance_hide_content_description">잔액 숨기기</string>
+    <string name="ltc_balance_show_content_description">잔액 표시</string>
+    <string name="ltc_balance_litecoin_content_description">라이트코인</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">동기화 중…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">블록: %1$d</string>
+    <string name="ltc_sync_last_block">마지막 블록: %1$s</string>
+    <string name="ltc_sync_date">날짜: %1$s</string>
+    <string name="ltc_sync_action_send">보내기</string>
+    <string name="ltc_sync_action_receive">받기</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">거래 내역</string>
+    <string name="ltc_transaction_history_empty">아직 거래가 없습니다</string>
+    <string name="ltc_transaction_export_content_description">내보내기</string>
+    <string name="ltc_transaction_received_content_description">받음</string>
+    <string name="ltc_transaction_sent_content_description">보냄</string>
+    <string name="ltc_transaction_from_address">%1$s에서</string>
+    <string name="ltc_transaction_to_address">%1$s로</string>
+    <string name="ltc_transaction_unknown_address">알 수 없음</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">극비</string>
+    <string name="ltc_favorite_add_contact_description">즐겨찾는 연락처 추가</string>
+</resources>

--- a/modules/ltc/src/main/res/values-pa/strings.xml
+++ b/modules/ltc/src/main/res/values-pa/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">ਤੁਹਾਡਾ ਬੈਲੇਂਸ</string>
+    <string name="ltc_balance_hide_content_description">ਬੈਲੇਂਸ ਲੁਕਾਓ</string>
+    <string name="ltc_balance_show_content_description">ਬੈਲੇਂਸ ਦਿਖਾਓ</string>
+    <string name="ltc_balance_litecoin_content_description">ਲਾਈਟਕੋਇਨ</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">ਸਿੰਕ ਹੋ ਰਿਹਾ ਹੈ…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">ਬਲਾਕ: %1$d</string>
+    <string name="ltc_sync_last_block">ਆਖਰੀ ਬਲਾਕ: %1$s</string>
+    <string name="ltc_sync_date">ਤਾਰੀਖ: %1$s</string>
+    <string name="ltc_sync_action_send">ਭੇਜੋ</string>
+    <string name="ltc_sync_action_receive">ਪ੍ਰਾਪਤ ਕਰੋ</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">ਲੈਣ-ਦੇਣ ਇਤਿਹਾਸ</string>
+    <string name="ltc_transaction_history_empty">ਅਜੇ ਤੱਕ ਕੋਈ ਲੈਣ-ਦੇਣ ਨਹੀਂ</string>
+    <string name="ltc_transaction_export_content_description">ਨਿਰਯਾਤ</string>
+    <string name="ltc_transaction_received_content_description">ਪ੍ਰਾਪਤ ਕੀਤਾ</string>
+    <string name="ltc_transaction_sent_content_description">ਭੇਜਿਆ</string>
+    <string name="ltc_transaction_from_address">%1$s ਤੋਂ</string>
+    <string name="ltc_transaction_to_address">%1$s ਨੂੰ</string>
+    <string name="ltc_transaction_unknown_address">ਅਣਜਾਣ</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">ਬਹੁਤ ਗੁਪਤ</string>
+    <string name="ltc_favorite_add_contact_description">ਮਨਪਸੰਦ ਸੰਪਰਕ ਸ਼ਾਮਲ ਕਰੋ</string>
+</resources>

--- a/modules/ltc/src/main/res/values-pl/strings.xml
+++ b/modules/ltc/src/main/res/values-pl/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">TWOJE SALDO</string>
+    <string name="ltc_balance_hide_content_description">Ukryj saldo</string>
+    <string name="ltc_balance_show_content_description">Pokaż saldo</string>
+    <string name="ltc_balance_litecoin_content_description">Litecoin</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Synchronizacja…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Blok: %1$d</string>
+    <string name="ltc_sync_last_block">Ostatni blok: %1$s</string>
+    <string name="ltc_sync_date">Data: %1$s</string>
+    <string name="ltc_sync_action_send">Wyślij</string>
+    <string name="ltc_sync_action_receive">Odbierz</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">HISTORIA TRANSAKCJI</string>
+    <string name="ltc_transaction_history_empty">Brak transakcji</string>
+    <string name="ltc_transaction_export_content_description">Eksportuj</string>
+    <string name="ltc_transaction_received_content_description">Otrzymano</string>
+    <string name="ltc_transaction_sent_content_description">Wysłano</string>
+    <string name="ltc_transaction_from_address">od %1$s</string>
+    <string name="ltc_transaction_to_address">do %1$s</string>
+    <string name="ltc_transaction_unknown_address">nieznany</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">ŚCIŚLE TAJNE</string>
+    <string name="ltc_favorite_add_contact_description">Dodaj ulubiony kontakt</string>
+</resources>

--- a/modules/ltc/src/main/res/values-pt/strings.xml
+++ b/modules/ltc/src/main/res/values-pt/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">SEU SALDO</string>
+    <string name="ltc_balance_hide_content_description">Ocultar saldo</string>
+    <string name="ltc_balance_show_content_description">Mostrar saldo</string>
+    <string name="ltc_balance_litecoin_content_description">Litecoin</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Sincronizando…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Bloco: %1$d</string>
+    <string name="ltc_sync_last_block">Último bloco: %1$s</string>
+    <string name="ltc_sync_date">Data: %1$s</string>
+    <string name="ltc_sync_action_send">Enviar</string>
+    <string name="ltc_sync_action_receive">Receber</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">HISTÓRICO DE TRANSAÇÕES</string>
+    <string name="ltc_transaction_history_empty">Ainda não há transações</string>
+    <string name="ltc_transaction_export_content_description">Exportar</string>
+    <string name="ltc_transaction_received_content_description">Recebido</string>
+    <string name="ltc_transaction_sent_content_description">Enviado</string>
+    <string name="ltc_transaction_from_address">de %1$s</string>
+    <string name="ltc_transaction_to_address">para %1$s</string>
+    <string name="ltc_transaction_unknown_address">desconhecido</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">ULTRASSECRETO</string>
+    <string name="ltc_favorite_add_contact_description">Adicionar contato favorito</string>
+</resources>

--- a/modules/ltc/src/main/res/values-ru/strings.xml
+++ b/modules/ltc/src/main/res/values-ru/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">ВАШ БАЛАНС</string>
+    <string name="ltc_balance_hide_content_description">Скрыть баланс</string>
+    <string name="ltc_balance_show_content_description">Показать баланс</string>
+    <string name="ltc_balance_litecoin_content_description">Лайткоин</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Синхронизация…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Блок: %1$d</string>
+    <string name="ltc_sync_last_block">Последний блок: %1$s</string>
+    <string name="ltc_sync_date">Дата: %1$s</string>
+    <string name="ltc_sync_action_send">Отправить</string>
+    <string name="ltc_sync_action_receive">Получить</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">ИСТОРИЯ ТРАНЗАКЦИЙ</string>
+    <string name="ltc_transaction_history_empty">Пока нет транзакций</string>
+    <string name="ltc_transaction_export_content_description">Экспорт</string>
+    <string name="ltc_transaction_received_content_description">Получено</string>
+    <string name="ltc_transaction_sent_content_description">Отправлено</string>
+    <string name="ltc_transaction_from_address">от %1$s</string>
+    <string name="ltc_transaction_to_address">к %1$s</string>
+    <string name="ltc_transaction_unknown_address">неизвестно</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">СОВЕРШЕННО СЕКРЕТНО</string>
+    <string name="ltc_favorite_add_contact_description">Добавить избранный контакт</string>
+</resources>

--- a/modules/ltc/src/main/res/values-sv/strings.xml
+++ b/modules/ltc/src/main/res/values-sv/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">DITT SALDO</string>
+    <string name="ltc_balance_hide_content_description">Dölj saldo</string>
+    <string name="ltc_balance_show_content_description">Visa saldo</string>
+    <string name="ltc_balance_litecoin_content_description">Litecoin</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Synkroniserar…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Block: %1$d</string>
+    <string name="ltc_sync_last_block">Senaste block: %1$s</string>
+    <string name="ltc_sync_date">Datum: %1$s</string>
+    <string name="ltc_sync_action_send">Skicka</string>
+    <string name="ltc_sync_action_receive">Ta emot</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">TRANSAKTIONSHISTORIK</string>
+    <string name="ltc_transaction_history_empty">Inga transaktioner ännu</string>
+    <string name="ltc_transaction_export_content_description">Exportera</string>
+    <string name="ltc_transaction_received_content_description">Mottaget</string>
+    <string name="ltc_transaction_sent_content_description">Skickat</string>
+    <string name="ltc_transaction_from_address">från %1$s</string>
+    <string name="ltc_transaction_to_address">till %1$s</string>
+    <string name="ltc_transaction_unknown_address">okänd</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">TOPPHEMLIGT</string>
+    <string name="ltc_favorite_add_contact_description">Lägg till favoritkontakt</string>
+</resources>

--- a/modules/ltc/src/main/res/values-tr/strings.xml
+++ b/modules/ltc/src/main/res/values-tr/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">BAKİYENİZ</string>
+    <string name="ltc_balance_hide_content_description">Bakiyeyi gizle</string>
+    <string name="ltc_balance_show_content_description">Bakiyeyi göster</string>
+    <string name="ltc_balance_litecoin_content_description">Litecoin</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Senkronize ediliyor…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Blok: %1$d</string>
+    <string name="ltc_sync_last_block">Son blok: %1$s</string>
+    <string name="ltc_sync_date">Tarih: %1$s</string>
+    <string name="ltc_sync_action_send">Gönder</string>
+    <string name="ltc_sync_action_receive">Al</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">İŞLEM GEÇMİŞİ</string>
+    <string name="ltc_transaction_history_empty">Henüz işlem yok</string>
+    <string name="ltc_transaction_export_content_description">Dışa aktar</string>
+    <string name="ltc_transaction_received_content_description">Alındı</string>
+    <string name="ltc_transaction_sent_content_description">Gönderildi</string>
+    <string name="ltc_transaction_from_address">%1$s adresinden</string>
+    <string name="ltc_transaction_to_address">%1$s adresine</string>
+    <string name="ltc_transaction_unknown_address">bilinmiyor</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">ÇOK GİZLİ</string>
+    <string name="ltc_favorite_add_contact_description">Favori kişi ekle</string>
+</resources>

--- a/modules/ltc/src/main/res/values-uk/strings.xml
+++ b/modules/ltc/src/main/res/values-uk/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">ВАШ БАЛАНС</string>
+    <string name="ltc_balance_hide_content_description">Приховати баланс</string>
+    <string name="ltc_balance_show_content_description">Показати баланс</string>
+    <string name="ltc_balance_litecoin_content_description">Лайткоїн</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Синхронізація…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Блок: %1$d</string>
+    <string name="ltc_sync_last_block">Останній блок: %1$s</string>
+    <string name="ltc_sync_date">Дата: %1$s</string>
+    <string name="ltc_sync_action_send">Надіслати</string>
+    <string name="ltc_sync_action_receive">Отримати</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">ІСТОРІЯ ТРАНЗАКЦІЙ</string>
+    <string name="ltc_transaction_history_empty">Поки немає транзакцій</string>
+    <string name="ltc_transaction_export_content_description">Експорт</string>
+    <string name="ltc_transaction_received_content_description">Отримано</string>
+    <string name="ltc_transaction_sent_content_description">Надіслано</string>
+    <string name="ltc_transaction_from_address">від %1$s</string>
+    <string name="ltc_transaction_to_address">до %1$s</string>
+    <string name="ltc_transaction_unknown_address">невідомо</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">ЦІЛКОМ ТАЄМНО</string>
+    <string name="ltc_favorite_add_contact_description">Додати улюблений контакт</string>
+</resources>

--- a/modules/ltc/src/main/res/values-zh-rCN/strings.xml
+++ b/modules/ltc/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">您的余额</string>
+    <string name="ltc_balance_hide_content_description">隐藏余额</string>
+    <string name="ltc_balance_show_content_description">显示余额</string>
+    <string name="ltc_balance_litecoin_content_description">莱特币</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">同步中…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">区块：%1$d</string>
+    <string name="ltc_sync_last_block">最后区块：%1$s</string>
+    <string name="ltc_sync_date">日期：%1$s</string>
+    <string name="ltc_sync_action_send">发送</string>
+    <string name="ltc_sync_action_receive">接收</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">交易历史</string>
+    <string name="ltc_transaction_history_empty">暂无交易</string>
+    <string name="ltc_transaction_export_content_description">导出</string>
+    <string name="ltc_transaction_received_content_description">已接收</string>
+    <string name="ltc_transaction_sent_content_description">已发送</string>
+    <string name="ltc_transaction_from_address">来自 %1$s</string>
+    <string name="ltc_transaction_to_address">发送至 %1$s</string>
+    <string name="ltc_transaction_unknown_address">未知</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">绝密</string>
+    <string name="ltc_favorite_add_contact_description">添加收藏联系人</string>
+</resources>

--- a/modules/ltc/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/ltc/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">您的餘額</string>
+    <string name="ltc_balance_hide_content_description">隱藏餘額</string>
+    <string name="ltc_balance_show_content_description">顯示餘額</string>
+    <string name="ltc_balance_litecoin_content_description">萊特幣</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">同步中…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">區塊：%1$d</string>
+    <string name="ltc_sync_last_block">最後區塊：%1$s</string>
+    <string name="ltc_sync_date">日期：%1$s</string>
+    <string name="ltc_sync_action_send">發送</string>
+    <string name="ltc_sync_action_receive">接收</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">交易記錄</string>
+    <string name="ltc_transaction_history_empty">尚無交易</string>
+    <string name="ltc_transaction_export_content_description">匯出</string>
+    <string name="ltc_transaction_received_content_description">已接收</string>
+    <string name="ltc_transaction_sent_content_description">已發送</string>
+    <string name="ltc_transaction_from_address">來自 %1$s</string>
+    <string name="ltc_transaction_to_address">發送至 %1$s</string>
+    <string name="ltc_transaction_unknown_address">未知</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">絕密</string>
+    <string name="ltc_favorite_add_contact_description">新增收藏聯絡人</string>
+</resources>

--- a/modules/ltc/src/main/res/values/strings.xml
+++ b/modules/ltc/src/main/res/values/strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: ltc -->
+    
+    <!-- Balance Components -->
+    <string name="ltc_balance_header_title">YOUR BALANCE</string>
+    <string name="ltc_balance_hide_content_description">Hide balance</string>
+    <string name="ltc_balance_show_content_description">Show balance</string>
+    <string name="ltc_balance_litecoin_content_description">Litecoin</string>
+    
+    <!-- Sync Components -->
+    <string name="ltc_sync_syncing_status">Syncing…</string>
+    <string name="ltc_sync_progress_percentage">%1$d%%</string>
+    <string name="ltc_sync_block_height">Block: %1$d</string>
+    <string name="ltc_sync_last_block">Last block: %1$s</string>
+    <string name="ltc_sync_date">Date: %1$s</string>
+    <string name="ltc_sync_action_send">Send</string>
+    <string name="ltc_sync_action_receive">Receive</string>
+    
+    <!-- Transaction History Components -->
+    <string name="ltc_transaction_history_title">TRANSACTION HISTORY</string>
+    <string name="ltc_transaction_history_empty">No transactions yet</string>
+    <string name="ltc_transaction_export_content_description">Export</string>
+    <string name="ltc_transaction_received_content_description">Received</string>
+    <string name="ltc_transaction_sent_content_description">Sent</string>
+    <string name="ltc_transaction_from_address">from %1$s</string>
+    <string name="ltc_transaction_to_address">to %1$s</string>
+    <string name="ltc_transaction_unknown_address">unknown</string>
+    
+    <!-- Favorite Contacts Components -->
+    <string name="ltc_favorite_chip_label">TOP SECRET</string>
+    <string name="ltc_favorite_add_contact_description">Add favorite contact</string>
+</resources>

--- a/modules/tutorial/build.gradle.kts
+++ b/modules/tutorial/build.gradle.kts
@@ -21,6 +21,11 @@ android {
         minSdk = 29
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        
+        resourceConfigurations += listOf(
+            "en", "ar", "de", "es", "fa", "fr", "hi", "in", "it", "ja",
+            "ko", "pa", "pl", "pt", "ru", "sv", "tr", "uk", "zh-rCN", "zh-rTW"
+        )
     }
 
     buildTypes {

--- a/modules/tutorial/src/main/java/com/brainwallet/tutorial/presentation/component/TutorialGrid.kt
+++ b/modules/tutorial/src/main/java/com/brainwallet/tutorial/presentation/component/TutorialGrid.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -24,6 +25,7 @@ import androidx.compose.ui.unit.sp
 import com.brainwallet.design.presentation.component.effect.CardOpacityContainer
 import com.brainwallet.design.presentation.component.widget.GridChip
 import com.brainwallet.design.presentation.component.widget.PaginationDot
+import com.brainwallet.tutorial.R
 import com.grunt.brainwallet.core.presentation.theme.BrainwalletTheme
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
@@ -31,21 +33,17 @@ import kotlinx.collections.immutable.persistentListOf
 data class TutorialData(
     val title: String,
     val body: String
-) {
-    companion object {
-        val default = persistentListOf(
-            TutorialData(
-                "Only you know the meaning!",
-                "Remember your seed phrase and train yourself"
-            )
-        )
-    }
-}
+)
 
 @Composable
 fun TutorialGrid(
     modifier: Modifier = Modifier,
-    tutorials: PersistentList<TutorialData> = TutorialData.default,
+    tutorials: PersistentList<TutorialData> = persistentListOf(
+        TutorialData(
+            title = stringResource(R.string.tutorial_grid_default_title),
+            body = stringResource(R.string.tutorial_grid_default_body)
+        )
+    ),
 ) {
     val pagerState = rememberPagerState(pageCount = { tutorials.size })
 
@@ -58,7 +56,7 @@ fun TutorialGrid(
                 .padding(16.dp),
             verticalArrangement = Arrangement.SpaceBetween
         ) {
-            GridChip("TUTORIALS", modifier = Modifier.padding(bottom = 3.dp))
+            GridChip(stringResource(R.string.tutorial_grid_chip_label), modifier = Modifier.padding(bottom = 3.dp))
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier.weight(1f)

--- a/modules/tutorial/src/main/res/values-ar/strings.xml
+++ b/modules/tutorial/src/main/res/values-ar/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">دروس</string>
+    <string name="tutorial_grid_default_title">أنت فقط تعرف المعنى!</string>
+    <string name="tutorial_grid_default_body">تذكر عبارة البذرة الخاصة بك ودرب نفسك</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-de/strings.xml
+++ b/modules/tutorial/src/main/res/values-de/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">TUTORIALS</string>
+    <string name="tutorial_grid_default_title">Nur du kennst die Bedeutung!</string>
+    <string name="tutorial_grid_default_body">Merke dir deine Seed-Phrase und trainiere dich</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-es/strings.xml
+++ b/modules/tutorial/src/main/res/values-es/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">TUTORIALES</string>
+    <string name="tutorial_grid_default_title">¡Solo tú conoces el significado!</string>
+    <string name="tutorial_grid_default_body">Recuerda tu frase semilla y entrénate</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-fa/strings.xml
+++ b/modules/tutorial/src/main/res/values-fa/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">آموزش‌ها</string>
+    <string name="tutorial_grid_default_title">فقط شما معنی را می‌دانید!</string>
+    <string name="tutorial_grid_default_body">عبارت بذر خود را به خاطر بسپارید و خود را تمرین دهید</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-fr/strings.xml
+++ b/modules/tutorial/src/main/res/values-fr/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">TUTORIELS</string>
+    <string name="tutorial_grid_default_title">Vous seul connaissez la signification!</string>
+    <string name="tutorial_grid_default_body">Mémorisez votre phrase de récupération et entraînez-vous</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-hi/strings.xml
+++ b/modules/tutorial/src/main/res/values-hi/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">ट्यूटोरियल</string>
+    <string name="tutorial_grid_default_title">केवल आप अर्थ जानते हैं!</string>
+    <string name="tutorial_grid_default_body">अपने सीड फ्रेज को याद रखें और खुद को प्रशिक्षित करें</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-in/strings.xml
+++ b/modules/tutorial/src/main/res/values-in/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">TUTORIAL</string>
+    <string name="tutorial_grid_default_title">Hanya Anda yang tahu artinya!</string>
+    <string name="tutorial_grid_default_body">Ingat frasa benih Anda dan latih diri Anda</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-it/strings.xml
+++ b/modules/tutorial/src/main/res/values-it/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">TUTORIAL</string>
+    <string name="tutorial_grid_default_title">Solo tu conosci il significato!</string>
+    <string name="tutorial_grid_default_body">Ricorda la tua frase seed e allenati</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-ja/strings.xml
+++ b/modules/tutorial/src/main/res/values-ja/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">チュートリアル</string>
+    <string name="tutorial_grid_default_title">あなただけが意味を知っています！</string>
+    <string name="tutorial_grid_default_body">シードフレーズを覚えて自分を訓練しましょう</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-ko/strings.xml
+++ b/modules/tutorial/src/main/res/values-ko/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">튜토리얼</string>
+    <string name="tutorial_grid_default_title">당신만이 의미를 알고 있습니다!</string>
+    <string name="tutorial_grid_default_body">시드 문구를 기억하고 스스로 훈련하세요</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-pa/strings.xml
+++ b/modules/tutorial/src/main/res/values-pa/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">ਟਿਊਟੋਰੀਅਲ</string>
+    <string name="tutorial_grid_default_title">ਸਿਰਫ਼ ਤੁਸੀਂ ਅਰਥ ਜਾਣਦੇ ਹੋ!</string>
+    <string name="tutorial_grid_default_body">ਆਪਣੇ ਸੀਡ ਵਾਕੰਸ਼ ਨੂੰ ਯਾਦ ਰੱਖੋ ਅਤੇ ਆਪਣੇ ਆਪ ਨੂੰ ਸਿਖਲਾਈ ਦਿਓ</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-pl/strings.xml
+++ b/modules/tutorial/src/main/res/values-pl/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">SAMOUCZKI</string>
+    <string name="tutorial_grid_default_title">Tylko ty znasz znaczenie!</string>
+    <string name="tutorial_grid_default_body">Zapamiętaj swoją frazę seed i trenuj się</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-pt/strings.xml
+++ b/modules/tutorial/src/main/res/values-pt/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">TUTORIAIS</string>
+    <string name="tutorial_grid_default_title">Só você conhece o significado!</string>
+    <string name="tutorial_grid_default_body">Lembre-se da sua frase semente e treine-se</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-ru/strings.xml
+++ b/modules/tutorial/src/main/res/values-ru/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">УЧЕБНИКИ</string>
+    <string name="tutorial_grid_default_title">Только вы знаете значение!</string>
+    <string name="tutorial_grid_default_body">Запомните свою сид-фразу и тренируйтесь</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-sv/strings.xml
+++ b/modules/tutorial/src/main/res/values-sv/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">HANDLEDNINGAR</string>
+    <string name="tutorial_grid_default_title">Bara du känner till betydelsen!</string>
+    <string name="tutorial_grid_default_body">Kom ihåg din seed-fras och träna dig själv</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-tr/strings.xml
+++ b/modules/tutorial/src/main/res/values-tr/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">EĞİTİMLER</string>
+    <string name="tutorial_grid_default_title">Sadece sen anlamı biliyorsun!</string>
+    <string name="tutorial_grid_default_body">Tohum ifadenizi hatırlayın ve kendinizi eğitin</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-uk/strings.xml
+++ b/modules/tutorial/src/main/res/values-uk/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">НАВЧАННЯ</string>
+    <string name="tutorial_grid_default_title">Тільки ви знаєте значення!</string>
+    <string name="tutorial_grid_default_body">Запам\'ятайте свою сід-фразу та тренуйтеся</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-zh-rCN/strings.xml
+++ b/modules/tutorial/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">教程</string>
+    <string name="tutorial_grid_default_title">只有你知道含义！</string>
+    <string name="tutorial_grid_default_body">记住你的助记词并训练自己</string>
+</resources>

--- a/modules/tutorial/src/main/res/values-zh-rTW/strings.xml
+++ b/modules/tutorial/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">教學</string>
+    <string name="tutorial_grid_default_title">只有你知道含義！</string>
+    <string name="tutorial_grid_default_body">記住你的助記詞並訓練自己</string>
+</resources>

--- a/modules/tutorial/src/main/res/values/strings.xml
+++ b/modules/tutorial/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Module: tutorial -->
+    
+    <!-- Grid Components -->
+    <string name="tutorial_grid_chip_label">TUTORIALS</string>
+    <string name="tutorial_grid_default_title">Only you know the meaning!</string>
+    <string name="tutorial_grid_default_body">Remember your seed phrase and train yourself</string>
+</resources>


### PR DESCRIPTION
## 📱 Description
This PR modernizes the home experience by replacing the legacy `BentoRail` with the new `HomeSettingDrawerSheet`, consolidating settings UI and simplifying state management. In addition, full localization support is introduced across multiple modules, adding translated resources for 19 languages.

## Platform
- [x] Android
- [ ] iOS
- [ ] Games-Unity
- [ ] DevOps (AWS)
- [ ] Website
- [ ] C/Golang

## 🎯 Type of Change
- [x] ✨ New feature
- [x] 🔧 Refactoring
- [x] 🎨 UI/UX improvement
- [ ] 🐛 Bug fix
- [ ] 📚 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement

## 📋 Changes

### 🔧 Replace BentoRail with HomeSettingDrawerSheet
- Removed the old `BentoRail` composable and integrated the `HomeSettingDrawerSheet` into `BentoMainScreen`.
- Centralized settings UI, removing redundant or duplicated logic across modules.
- Updated `BentoActivity` to inherit from `BreadActivity`, leveraging shared functionality and enabling legacy UI events via `EventBus`.
- Updated `BreadActivity` methods and fields to `protected` so `BentoActivity` can extend them safely.
- Moved dark mode toggle logic from `SettingsViewModel` directly into `DarkModeState` within the drawer sheet.
- Removed obsolete rail-related logic from `BentoMainScreen` and `SettingsViewModel`.

### ✨ Localization for Multilingual Support
- Added translated `strings.xml` files for 19 languages:
  Arabic, German, Spanish, Farsi, French, Hindi, Indonesian, Italian, Japanese, Korean, Punjabi, Polish, Portuguese, Russian, Swedish, Turkish, Ukrainian, Simplified Chinese, and Traditional Chinese.
- Externalized previously hardcoded strings across `design-system`, `ltc`, `gamehub`, and `tutorial` modules.
- Updated Gradle configuration to ensure all new language resources are included in packaging.

### 🔗 Related Issues
- Close https://github.com/gruntsoftware/internal/issues/280#event-21094840531

## 🧪 Tests Status
- [ ] Tests ran successfully locally
- [ ] Added more tests
- Code coverage percentage of the codebase: __%

## 🎯 Reviewers
@kcw-grunt, @josikie
