### PR TITLE
🔨  Fix: moved out of the state update for the filter toggle

### DIFF
--- a/app/src/main/java/com/brainwallet/tools/manager/AnalyticsManager.java
+++ b/app/src/main/java/com/brainwallet/tools/manager/AnalyticsManager.java
@@ -23,8 +23,8 @@ public final class AnalyticsManager {
         return null;
     }
 
-    public static Object logQuickEvent(String quickEvent, Bundle params) {
-        instance.logEvent(quickEvent, params);
+    public static Object logCustomAdHocEvent(String adHocEvent) {
+        instance.logEvent(adHocEvent, null);
         return null;
     }
 

--- a/app/src/main/java/com/brainwallet/ui/screens/main/MainViewModel.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/main/MainViewModel.kt
@@ -359,14 +359,12 @@ class MainViewModel(
                             (txItem.received - txItem.sent < 0)
                         }.toImmutableList()
                     }
-                    Timber.d("timber: filtered state: $nextFilter and transactions: ${filteredTransactions.size}")
-                    AnalyticsManager.logCustomEventWithParams("did_toggle_transaction_filter", null)
-
                     it.copy(
                         filterState = nextFilter,
                         transactionItems = filteredTransactions
                     )
                 }
+                AnalyticsManager.logCustomAdHocEvent("did_toggle_txn_filter")
             }
             is MainScreenEvent.OnExportTransactions -> {
                 // TODO: Implement


### PR DESCRIPTION
## 📱 Description
This PR refactors the analytics event logging in the transaction filter toggle flow. It removes analytics logging and debug logging from within the state update operation in `MainViewModel`, moving the analytics call outside the state copy operation. Additionally, the `AnalyticsManager.logQuickEvent()` method is renamed to `logCustomAdHocEvent()` and simplified to not accept bundle parameters. 
> 🤖 _Auto-generated by GitHub Copilot

## Platform
- [x] **Android**

## 🎯 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 🔧 Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement

## 📋 Changes
### New Components Added
None

### Modifications
- **AnalyticsManager.java**: Renamed `logQuickEvent(String, Bundle)` to `logCustomAdHocEvent(String)` and simplified the method signature to only accept an event name parameter, passing `null` for the bundle internally.
- **MainViewModel.kt**: Moved `AnalyticsManager.logCustomAdHocEvent()` call outside the state update block (after the `it.copy()` operation). Removed the debug `Timber.d()` log statement and the previous `logCustomEventWithParams()` call that were within the state update. Updated the analytics event name to `"did_toggle_txn_filter"`.

### Removals
- Removed `Timber.d("timber: filtered state: $nextFilter and transactions: ${filteredTransactions.size}")` debug logging from the state update block in `MainViewModel`.
- Removed `AnalyticsManager.logCustomEventWithParams("did_toggle_transaction_filter", null)` call from within the state update block.

## 📊 Statistics
- **Additions:** 3 lines
- **Deletions:** 5 lines
- **Files Changed:** 2
- **Commits:** 1

## 🔗 Related Issues
- Fixes #
- Related to #

## 🧪 Tests Status
- [ ] Tests ran successfully locally?
- [ ] Added more tests? How many?
- [ ] Code coverage percentage of the codebase: __%

## 📸 Screenshots/Videos
| Before | After |
|--------|-------|
| _Add screenshot_ | _Add screenshot_ |

## 🎯 Reviewers
@kcw-grunt, @josikie

---
**Draft Status:** This PR is currently in draft mode and ready for review feedback.