### PR TITLE
😱 🐞fix: issue when user tries to send

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,7 +34,7 @@ android {
         applicationId = "ltd.grunt.brainwallet"
         minSdk = 29
         targetSdk = 35
-        versionCode = 202506320
+        versionCode = 202506322
         versionName = "v4.9.1"
         multiDexEnabled = true
         base.archivesName.set("${defaultConfig.versionName}(${defaultConfig.versionCode})")

--- a/app/src/main/java/com/brainwallet/tools/security/LitecoinURIHandler.java
+++ b/app/src/main/java/com/brainwallet/tools/security/LitecoinURIHandler.java
@@ -1,0 +1,110 @@
+package com.brainwallet.tools.security;
+
+import com.brainwallet.R;
+import com.brainwallet.presenter.customviews.BRDialogView;
+import com.brainwallet.presenter.entities.PaymentRequestWrapper;
+import com.brainwallet.presenter.entities.RequestObject;
+import com.brainwallet.tools.animation.BRDialog;
+import com.brainwallet.tools.threads.PaymentProtocolTask;
+import com.brainwallet.util.EventBus;
+import com.brainwallet.wallet.BRWalletManager;
+import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.URLDecoder;
+import timber.log.Timber;
+
+import androidx.fragment.app.FragmentActivity;
+
+public class LitecoinURIHandler {
+
+    public static RequestObject getRequestFromString(String str) {
+        if (str == null || str.isEmpty()) return null;
+        RequestObject obj = new RequestObject();
+
+        String tmp = str.trim().replaceAll("\n", "").replaceAll(" ", "%20");
+
+        if (!tmp.startsWith("litecoin://")) {
+            if (!tmp.startsWith("litecoin:"))
+                tmp = "litecoin://".concat(tmp);
+            else
+                tmp = tmp.replace("litecoin:", "litecoin://");
+        }
+        URI uri;
+        try {
+            uri = URI.create(tmp);
+        } catch (IllegalArgumentException ex) {
+            Timber.e(ex, "getRequestFromString: ");
+            return null;
+        }
+
+        String host = uri.getHost();
+        if (host != null) {
+            String addrs = host.trim();
+            if (BRWalletManager.validateAddress(addrs)) {
+                obj.address = addrs;
+            }
+        }
+        String query = uri.getQuery();
+        if (query == null) return obj;
+        String[] params = query.split("&");
+        for (String s : params) {
+            String[] keyValue = s.split("=", 2);
+            if (keyValue.length != 2)
+                continue;
+            if (keyValue[0].trim().equals("amount")) {
+                try {
+                    BigDecimal bigDecimal = new BigDecimal(keyValue[1].trim());
+                    obj.amount = bigDecimal.multiply(new BigDecimal("100000000")).toString();
+                } catch (NumberFormatException e) {
+                    Timber.e(e);
+                }
+            } else if (keyValue[0].trim().equals("label")) {
+                obj.label = keyValue[1].trim();
+            } else if (keyValue[0].trim().equals("message")) {
+                obj.message = keyValue[1].trim();
+            } else if (keyValue[0].trim().startsWith("req")) {
+                obj.req = keyValue[1].trim();
+            } else if (keyValue[0].trim().startsWith("r")) {
+                obj.r = keyValue[1].trim();
+            }
+        }
+        return obj;
+    }
+
+    public static boolean isValidLitecoinURI(String url) {
+        RequestObject requestObject = getRequestFromString(url);
+        // return true if the request is valid url and has param: r or param: address
+        // return true if it is a valid bitcoinPrivKey
+        return (requestObject != null && (requestObject.r != null || requestObject.address != null)
+            || BRWalletManager.getInstance().isValidBitcoinBIP38Key(url)
+            || BRWalletManager.getInstance().isValidBitcoinPrivateKey(url));
+    }
+
+    public static boolean isValidLitecoinUrl(String url) {
+        if (isValidLitecoinURI(url)) {
+            return BRWalletManager.validateAddress(url);
+        }
+        return false;
+    }
+
+    private static boolean tryLitecoinURL(final String url, final FragmentActivity app) {
+        RequestObject requestObject = getRequestFromString(url);
+        if (requestObject == null || requestObject.address == null || requestObject.address.isEmpty())
+            return false;
+
+        String amount = requestObject.amount;
+
+        if (amount == null || amount.isEmpty() || new BigDecimal(amount).doubleValue() == 0) {
+            app.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    EventBus.INSTANCE.postQRCodeScanned(requestObject.address);
+                }
+            });
+        }
+        return true;
+    }
+
+
+}

--- a/app/src/main/java/com/brainwallet/ui/screens/send/PreSend.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/send/PreSend.kt
@@ -1,4 +1,5 @@
 package com.brainwallet.ui.screens.send
+import android.R.attr.value
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/brainwallet/ui/screens/send/PreSendAddressRow.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/send/PreSendAddressRow.kt
@@ -19,11 +19,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
@@ -58,6 +58,10 @@ fun PreSendAddressRow(
     )
     val context = LocalContext.current
 
+    LaunchedEffect(value) {
+        onEvent(SendEvent.OnRecipientAddressChanged(value))
+    }
+
     Box(
         modifier = Modifier
             .height(sectionHeight)
@@ -81,12 +85,7 @@ fun PreSendAddressRow(
                 modifier = Modifier.fillMaxWidth(0.65F)
             ) {
                 TextField(
-                    modifier = Modifier.height(sectionHeight)
-                        .onFocusChanged { focusState ->
-                            if (focusState.hasFocus) {
-                                onEvent(SendEvent.OnFieldFocused)
-                            }
-                        },
+                    modifier = Modifier.height(sectionHeight),
                     value = value,
                     onValueChange = {
                         onEvent(SendEvent.OnRecipientAddressChanged(it))

--- a/app/src/main/java/com/brainwallet/ui/screens/send/SendViewModel.kt
+++ b/app/src/main/java/com/brainwallet/ui/screens/send/SendViewModel.kt
@@ -86,6 +86,8 @@ class SendViewModel(
                 val address = _state.value.recipientLTCAddress
                 if (address.isNotBlank()) {
                     val isValid = BRWalletManager.validateAddress(address)
+                    Timber.d("OnTapPasteLTCAddress SendViewModel: isValid : $isValid")
+
                     _state.update {
                         it.copy(
                             isLTCAddressValid = isValid,
@@ -106,6 +108,8 @@ class SendViewModel(
             }
             is SendEvent.OnTapPasteLTCAddress -> {
                 val litecoinUrl = BRClipboardManager.getClipboard(app)
+                Timber.d("timber: OnTapPasteLTCAddress: $litecoinUrl")
+
                 val isAddressValid = BRWalletManager.validateAddress(litecoinUrl)
                 if (isAddressValid) {
                     _state.update {
@@ -222,8 +226,7 @@ class SendViewModel(
                     it.copy(
                         amountString = event.amountInLTCString,
                         isAmountBelowBalance = isAmountValid,
-                        isReadyToSend = isAmountValid &&
-                            BRWalletManager.validateAddress(it.recipientLTCAddress),
+                        isReadyToSend = isAmountValid && it.isLTCAddressValid,
                         networkFees = BigDecimal(networkFee.toDouble()),
                         serviceFees = BigDecimal(opsFee),
                         amountInLitoshi = BigDecimal(litoshiAmount)
@@ -306,10 +309,14 @@ class SendViewModel(
                 _state.update { it.copy(userMemorandum = event.memo) }
             }
             is SendEvent.OnFieldFocused -> {
+                Timber.d(
+                    "timber: is ${_state.value.isAmountBelowBalance}" +
+                        "\ntimber: isLTC${_state.value.isLTCAddressValid}"
+                )
+
                 _state.update {
                     it.copy(
-                        isReadyToSend = it.isAmountBelowBalance &&
-                            BRWalletManager.validateAddress(it.recipientLTCAddress),
+                        isReadyToSend = (it.isAmountBelowBalance && it.isLTCAddressValid)
                     )
                 }
             }


### PR DESCRIPTION
## 📱 Description
This PR fixes an issue with the send transaction flow by refactoring address validation logic in the SendViewModel and PreSendAddressRow composable. It introduces a new LitecoinURIHandler utility class to parse and validate Litecoin URIs, and replaces reactive focus-based validation with a LaunchedEffect that triggers validation whenever the recipient address changes. The fix ensures that the "Ready to Send" button state is correctly computed based on cached validation results rather than repeated address validation calls.
🤖 _Auto-generated by GitHub Copilot — edit as needed before merging._
## Platform
- [x] **Android**

## 🎯 Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement

## 📋 Changes
### New Components Added
- **LitecoinURIHandler.java** – Utility class to parse and validate Litecoin URIs (litecoin:// scheme), extract address/amount/label/message parameters, and validate BIP38 keys and private keys
- Added caller when the value is updated
bump version

### Modifications
- **SendViewModel.kt** – Updated `OnRecipientAddressChanged` and `OnFieldFocused` event handlers to use cached `isLTCAddressValid` state instead of calling `BRWalletManager.validateAddress()` repeatedly; added Timber debug logging for address validation and field focus state
- **PreSendAddressRow.kt** – Replaced `onFocusChanged` modifier with `LaunchedEffect` to trigger address validation whenever the `value` parameter changes; removed focus-based event triggering in favor of parameter-change-based validation
- **app/build.gradle.kts** – Incremented `versionCode` from 202506320 to 202506322

### Removals
None

## 📊 Statistics
- **Additions:** 129 lines
- **Deletions:** 12 lines
- **Files Changed:** 5
- **Commits:** 1

## 🔗 Related Issues
- Fixes # _(Issue number not specified in PR title)_
- Related to # _(None specified)_

## 🧪 Tests Status
- [ ] Tests ran successfully locally?
- [ ] Added more tests? How many?
- [ ] Code coverage percentage of the codebase: __%

## 📸 Screenshots/Videos
| Before | After |
|--------|-------|
| _Add screenshot_ | _Add screenshot_ |

## 🎯 Reviewers
@kcw-grunt, @josikie

--- 

---

### 🔍 Review Notes for Maintainers
- ⚠️ **Unused Import:** `PreSend.kt` imports `android.R.attr.value` but it's not used in the file—recommend removing
- ⚠️ **LitecoinURIHandler Methods:** The `isValidLitecoinUrl()` and `tryLitecoinURL()` methods are defined but not referenced in the diff—confirm they're called elsewhere or mark as unused
- ✅ **State Caching:** The shift from repeated `BRWalletManager.validateAddress()` calls to using cached `isLTCAddressValid` state is more efficient and correct
- ✅ **LaunchedEffect Pattern:** Using `LaunchedEffect(value)` in `PreSendAddressRow` ensures validation triggers on address changes and follows Compose best practices
